### PR TITLE
Upgrade tx notifications

### DIFF
--- a/apps/nextjs/src/app/(app)/account/assets/BridgeNftWrapper.tsx
+++ b/apps/nextjs/src/app/(app)/account/assets/BridgeNftWrapper.tsx
@@ -1,5 +1,6 @@
 "use client";
-
+import useStore from "@/hooks/useStore";
+import { useTransactionManager } from "@/stores/useTransasctionManager";
 import { useState } from "react";
 import { usePendingRealmsWithdrawals } from "@/hooks/bridge/data/usePendingRealmsWithdrawals";
 import EthereumLogo from "@/icons/ethereum.svg";
@@ -7,6 +8,7 @@ import StarknetLogo from "@/icons/starknet.svg";
 import { useUIStore } from "@/providers/UIStoreProvider";
 import { TriangleAlert } from "lucide-react";
 import { useAccount } from "wagmi";
+import { TransactionFinalityStatus } from "starknet";
 
 import { Collections } from "@realms-world/constants";
 import {
@@ -25,12 +27,14 @@ import AssetL1CollectionPreview from "./AssetL1CollectionPreview";
 import AssetL2CollectionPreview from "./AssetL2CollectionPreview";
 
 export const BridgeNftWrapper = () => {
+  const transactionState = useStore(useTransactionManager, (state) => state);
+  const allTransactionsProcessed = transactionState?.allTransacationsProcessed;
   const [activeChain, setActiveChain] = useState("l1");
   const { address } = useAccount();
   const { data: pendingWithdrawals } = usePendingRealmsWithdrawals({
     address,
-    status: "ACCEPTED_ON_L1",
-  });
+    status: TransactionFinalityStatus.ACCEPTED_ON_L1,
+  }, allTransactionsProcessed);
   const { toggleAccount } = useUIStore((state) => state);
 
   return (

--- a/apps/nextjs/src/app/(app)/account/assets/BridgeNftWrapper.tsx
+++ b/apps/nextjs/src/app/(app)/account/assets/BridgeNftWrapper.tsx
@@ -27,14 +27,13 @@ import AssetL1CollectionPreview from "./AssetL1CollectionPreview";
 import AssetL2CollectionPreview from "./AssetL2CollectionPreview";
 
 export const BridgeNftWrapper = () => {
-  const transactionState = useStore(useTransactionManager, (state) => state);
-  const allTransactionsProcessed = transactionState?.allTransacationsProcessed;
+
   const [activeChain, setActiveChain] = useState("l1");
   const { address } = useAccount();
   const { data: pendingWithdrawals } = usePendingRealmsWithdrawals({
     address,
     status: TransactionFinalityStatus.ACCEPTED_ON_L1,
-  }, allTransactionsProcessed);
+  });
   const { toggleAccount } = useUIStore((state) => state);
 
   return (

--- a/apps/nextjs/src/app/(app)/games/page.tsx
+++ b/apps/nextjs/src/app/(app)/games/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { GameCard } from "@/app/(app)/games/GameCard";
 import { reader } from "@/utils/keystatic";
-import { env } from 'env'
 
 import { PageLayout } from "../../_components/PageLayout";
 

--- a/apps/nextjs/src/app/(app)/games/page.tsx
+++ b/apps/nextjs/src/app/(app)/games/page.tsx
@@ -21,19 +21,6 @@ export default async function Page() {
         {games.map((game, index) => (
           <GameCard key={index} game={game.entry} slug={game.slug} />
         ))}
-        {`
-    \n1:${env.NEXT_PUBLIC_ALCHEMY_API}
-    \n2:${env.NEXT_PUBLIC_APIBARA_HANDLE}
-    \n3:${env.NEXT_PUBLIC_BLAST_API}
-    \n4:${env.NEXT_PUBLIC_ETHERSCAN_URL}
-    \n5:${env.NEXT_PUBLIC_ETHPLORER_APIKEY}
-    \n6:${env.NEXT_PUBLIC_REALMS_BRIDGE_SUBGRAPH_NAME}
-    \n7:${env.NEXT_PUBLIC_REALMS_LEGACY_REWARD_SUBGRAPH_NAME}
-    \n8:${env.NEXT_PUBLIC_REALMS_SUBGRAPH_NAME}
-    \n9:${env.NEXT_PUBLIC_RESERVOIR_API_KEY}
-    \n10:${env.NEXT_PUBLIC_STARKSCAN_URL}
-    \n12:${env.NEXT_PUBLIC_SUBGRAPH_NAME}
-    \n13:${env.NEXT_PUBLIC_VOYAGER_URL} `}
       </div>
       <div>
 

--- a/apps/nextjs/src/app/(app)/games/page.tsx
+++ b/apps/nextjs/src/app/(app)/games/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { GameCard } from "@/app/(app)/games/GameCard";
 import { reader } from "@/utils/keystatic";
+import { env } from 'env'
 
 import { PageLayout } from "../../_components/PageLayout";
 
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
 
 
 export default async function Page() {
+
   const games = await reader.collections.games.all();
   return (
     <PageLayout title="Onchain Games">
@@ -19,10 +21,24 @@ export default async function Page() {
         {games.map((game, index) => (
           <GameCard key={index} game={game.entry} slug={game.slug} />
         ))}
+        {`
+    \n1:${env.NEXT_PUBLIC_ALCHEMY_API}
+    \n2:${env.NEXT_PUBLIC_APIBARA_HANDLE}
+    \n3:${env.NEXT_PUBLIC_BLAST_API}
+    \n4:${env.NEXT_PUBLIC_ETHERSCAN_URL}
+    \n5:${env.NEXT_PUBLIC_ETHPLORER_APIKEY}
+    \n6:${env.NEXT_PUBLIC_REALMS_BRIDGE_SUBGRAPH_NAME}
+    \n7:${env.NEXT_PUBLIC_REALMS_LEGACY_REWARD_SUBGRAPH_NAME}
+    \n8:${env.NEXT_PUBLIC_REALMS_SUBGRAPH_NAME}
+    \n9:${env.NEXT_PUBLIC_RESERVOIR_API_KEY}
+    \n10:${env.NEXT_PUBLIC_STARKSCAN_URL}
+    \n12:${env.NEXT_PUBLIC_SUBGRAPH_NAME}
+    \n13:${env.NEXT_PUBLIC_VOYAGER_URL} `}
       </div>
       <div>
 
       </div>
     </PageLayout>
+
   );
 }

--- a/apps/nextjs/src/app/_components/TopNav.tsx
+++ b/apps/nextjs/src/app/_components/TopNav.tsx
@@ -6,8 +6,11 @@ import PieChart from "@/icons/pie-chart.svg";
 import RealmsL3 from "@/icons/realms_l3.svg";
 import { useUIStore } from "@/providers/UIStoreProvider";
 import { HammerIcon, Menu /*, ShieldQuestion*/ } from "lucide-react";
+import useStore from "@/hooks/useStore";
+import { useTransactionManager } from "@/stores/useTransasctionManager";
 import Crown from "@/icons/crown.svg";
 import {
+  Badge,
   Button,
   NavigationMenu,
   NavigationMenuContent,
@@ -21,8 +24,11 @@ import { EthereumLoginButton } from "./wallet/EthereumLoginButton";
 import { LordsDropdown } from "./wallet/LordsDropdown";
 import { StarknetLoginButton } from "./wallet/StarknetLoginButton";
 
+
 export const TopNav = () => {
   const { toggleSidebar } = useUIStore((state) => state);
+  const transactionState = useStore(useTransactionManager, (state) => state);
+  const newTransactionCount = transactionState?.newTransactionCount;
 
   const aboutLinks = [
     /*{
@@ -144,9 +150,11 @@ export const TopNav = () => {
             textClass="group-hover:block"
           />
           <StarknetLoginButton
+            buttonClass="relative"
             textClass="group-hover:block"
             variant={"default"}
             openAccount
+            newTransactionCount={newTransactionCount}
           />
         </div>
       </div>

--- a/apps/nextjs/src/app/_components/TopNav.tsx
+++ b/apps/nextjs/src/app/_components/TopNav.tsx
@@ -10,7 +10,6 @@ import useStore from "@/hooks/useStore";
 import { useTransactionManager } from "@/stores/useTransasctionManager";
 import Crown from "@/icons/crown.svg";
 import {
-  Badge,
   Button,
   NavigationMenu,
   NavigationMenuContent,

--- a/apps/nextjs/src/app/_components/wallet/ExplorerLink.tsx
+++ b/apps/nextjs/src/app/_components/wallet/ExplorerLink.tsx
@@ -6,7 +6,7 @@ import {
   STARKSCAN_TX_URL,
   SUPPORTED_L1_CHAIN_ID,
 } from "@/constants/env";
-import { ExternalLinkIcon, Text } from "lucide-react";
+import { ExternalLinkIcon } from "lucide-react";
 
 import type { ChainId } from "@realms-world/constants";
 import { Button } from "@realms-world/ui";

--- a/apps/nextjs/src/app/_components/wallet/ExplorerLink.tsx
+++ b/apps/nextjs/src/app/_components/wallet/ExplorerLink.tsx
@@ -6,7 +6,7 @@ import {
   STARKSCAN_TX_URL,
   SUPPORTED_L1_CHAIN_ID,
 } from "@/constants/env";
-import { ExternalLinkIcon } from "lucide-react";
+import { ExternalLinkIcon, Text } from "lucide-react";
 
 import type { ChainId } from "@realms-world/constants";
 import { Button } from "@realms-world/ui";
@@ -35,7 +35,7 @@ export const ExplorerLink = ({
   return (
     <Button key={text} variant={"outline"} size={"xs"} asChild>
       <Link href={explorerURL} target="_blank">
-        {text ?? isL1 ? "Etherscan" : "Starkscan"}
+        {text}
         <ExternalLinkIcon className="h-4" />
       </Link>
     </Button>

--- a/apps/nextjs/src/app/_components/wallet/StarknetLoginButton.tsx
+++ b/apps/nextjs/src/app/_components/wallet/StarknetLoginButton.tsx
@@ -8,7 +8,7 @@ import { shortenHex } from "@/utils/utils";
 import { useAccount } from "@starknet-react/core";
 
 import type { buttonVariants } from "@realms-world/ui";
-import { Button, Badge } from "@realms-world/ui";
+import { Button } from "@realms-world/ui";
 import { Loader } from "lucide-react";
 
 export const StarknetLoginButton = ({
@@ -55,7 +55,7 @@ export const StarknetLoginButton = ({
         </span>
       </span>
       {(isConnected && newTransactionCount) && newTransactionCount > 0 ? <span
-        className={'bg-green-500 w-[20px] absolute -top-1.5 -right-1.5 rounded-full text-black-600'}
+        className={'bg-green-600 w-[20px] absolute -top-1.5 -right-1.5 rounded-full text-black'}
       >{newTransactionCount}</span> : null}
     </Button>
   );

--- a/apps/nextjs/src/app/_components/wallet/StarknetLoginButton.tsx
+++ b/apps/nextjs/src/app/_components/wallet/StarknetLoginButton.tsx
@@ -54,7 +54,7 @@ export const StarknetLoginButton = ({
           }
         </span>
       </span>
-      {newTransactionCount && newTransactionCount > 0 ? <span
+      {(isConnected && newTransactionCount) && newTransactionCount > 0 ? <span
         className={'bg-green-500 w-[20px] absolute -top-1.5 -right-1.5 rounded-full text-black-600'}
       >{newTransactionCount}</span> : null}
     </Button>

--- a/apps/nextjs/src/app/_components/wallet/StarknetLoginButton.tsx
+++ b/apps/nextjs/src/app/_components/wallet/StarknetLoginButton.tsx
@@ -8,7 +8,7 @@ import { shortenHex } from "@/utils/utils";
 import { useAccount } from "@starknet-react/core";
 
 import type { buttonVariants } from "@realms-world/ui";
-import { Button } from "@realms-world/ui";
+import { Button, Badge } from "@realms-world/ui";
 import { Loader } from "lucide-react";
 
 export const StarknetLoginButton = ({
@@ -17,12 +17,14 @@ export const StarknetLoginButton = ({
   textClass,
   buttonClass,
   children,
+  newTransactionCount
 }: {
   openAccount?: boolean;
   variant?: VariantProps<typeof buttonVariants>["variant"];
   textClass?: string;
   buttonClass?: string;
-  children?: React.ReactNode;
+  children?: React.ReactNode,
+  newTransactionCount?: number
 }) => {
   const { account, isConnected, isConnecting } = useAccount();
   const { toggleAccount, toggleStarknetLogin } = useUIStore((state) => state);
@@ -52,6 +54,9 @@ export const StarknetLoginButton = ({
           }
         </span>
       </span>
+      {newTransactionCount && newTransactionCount > 0 ? <span
+        className={'bg-green-500 w-[20px] absolute -top-1.5 -right-1.5 rounded-full text-black-600'}
+      >{newTransactionCount}</span> : null}
     </Button>
   );
 };

--- a/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
+++ b/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
@@ -6,7 +6,8 @@ import { Account } from "@/app/(app)/bridge/Account";
 import Bridge from "@/icons/bridge.svg";
 import { useUIStore } from "@/providers/UIStoreProvider";
 import { useAccount as useL2Account, useNetwork } from "@starknet-react/core";
-
+import useStore from "@/hooks/useStore";
+import { useTransactionManager } from "@/stores/useTransasctionManager";
 import {
   Button,
   Dialog,
@@ -27,9 +28,11 @@ import {
 import { WrongNetworkModal } from "../modal/WrongNetworkModal";
 import EthereumAccount from "./EthereumAccount";
 import StarkAccount from "./StarkAccount";
-import { TransactionList } from "./transactions/TransactionList";
+import { QueryTransactionList, LocalStorageTransactionList } from "./transactions/TransactionList";
 
 export const WalletSheet = () => {
+  const transactionState = useStore(useTransactionManager, (state) => state);
+  const allTransactionsProcessed = transactionState?.allTransacationsProcessed;
   const {
     isConnected: isL2Connected,
     chainId,
@@ -124,7 +127,7 @@ export const WalletSheet = () => {
                 </Dialog>
               </div>
             </div>
-            <TransactionList />
+            {allTransactionsProcessed ? <LocalStorageTransactionList /> : <QueryTransactionList />}
           </div>
         </SheetContent>
       </Sheet>

--- a/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
+++ b/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
@@ -51,9 +51,9 @@ export const WalletSheet = () => {
   function usePrevious(isAccountOpen: boolean) {
     const ref = useRef<boolean>();
     useEffect(() => {
-      ref.current = isAccountOpen; //assign the value of ref to the argument
-    }, [isAccountOpen]); //this code will run when the value of 'value' changes
-    return ref.current; //in the end, return the current ref value.
+      ref.current = isAccountOpen;
+    }, [isAccountOpen]);
+    return ref.current;
   }
 
 

--- a/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
+++ b/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
@@ -33,7 +33,7 @@ import { QueryTransactionList, LocalStorageTransactionList } from "./transaction
 export const WalletSheet = () => {
   const transactionState = useStore(useTransactionManager, (state) => state);
   const newTransactionCount = transactionState?.newTransactionCount;
-  const combinedtransactions = transactionState?.combinedTransactions;
+  const allTransactionsProcessed = transactionState?.allTransactionsProcessed
 
   const {
     isConnected: isL2Connected,
@@ -54,7 +54,7 @@ export const WalletSheet = () => {
     return ref.current;
   }
 
-
+  console.log(newTransactionCount, allTransactionsProcessed)
   //after user closes wallet sheet, reset transactioncount in localstorage
   const previousAccountOpenState = usePrevious(isAccountOpen)
   useEffect(() => {
@@ -146,7 +146,7 @@ export const WalletSheet = () => {
                 </Dialog>
               </div>
             </div>
-            {(newTransactionCount && newTransactionCount > 0) || !combinedtransactions ? <QueryTransactionList /> : <LocalStorageTransactionList />}
+            {((newTransactionCount && newTransactionCount > 0) || allTransactionsProcessed === false) ? <QueryTransactionList /> : <LocalStorageTransactionList />}
           </div>
         </SheetContent>
       </Sheet>

--- a/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
+++ b/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
@@ -33,6 +33,7 @@ import { QueryTransactionList, LocalStorageTransactionList } from "./transaction
 export const WalletSheet = () => {
   const transactionState = useStore(useTransactionManager, (state) => state);
   const newTransactionCount = transactionState?.newTransactionCount;
+  const combinedtransactions = transactionState?.combinedTransactions;
 
   const {
     isConnected: isL2Connected,
@@ -145,7 +146,7 @@ export const WalletSheet = () => {
                 </Dialog>
               </div>
             </div>
-            {newTransactionCount && newTransactionCount > 0 ? <QueryTransactionList /> : <LocalStorageTransactionList />}
+            {(newTransactionCount && newTransactionCount > 0) || !combinedtransactions ? <QueryTransactionList /> : <LocalStorageTransactionList />}
           </div>
         </SheetContent>
       </Sheet>

--- a/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
+++ b/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
@@ -54,8 +54,8 @@ export const WalletSheet = () => {
     return ref.current;
   }
 
-  console.log(newTransactionCount, allTransactionsProcessed)
-  //after user closes wallet sheet, reset transactioncount in localstorage
+
+  //after user closes wallet sheet, reset transactioncount and alltransactionsprocessed in localstorage
   const previousAccountOpenState = usePrevious(isAccountOpen)
   useEffect(() => {
     if (isAccountOpen === false && previousAccountOpenState === true) {
@@ -146,6 +146,8 @@ export const WalletSheet = () => {
                 </Dialog>
               </div>
             </div>
+            {/* if newTransactioncount is greater than zero, toggle querylist to add new transaction to combinedTransactions */}
+            {/* alltrsansactionsprocessed === false handles the scenario where user has not opened their wallet sheet yet. IE incognito window, or the localstorage state isn't set yet */}
             {((newTransactionCount && newTransactionCount > 0) || allTransactionsProcessed === false) ? <QueryTransactionList /> : <LocalStorageTransactionList />}
           </div>
         </SheetContent>

--- a/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
+++ b/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
@@ -54,7 +54,7 @@ export const WalletSheet = () => {
   }
 
 
-  //after user closes wallet sheet, reset transactions and transactioncount in localstorage
+  //after user closes wallet sheet, reset transactioncount in localstorage
   const previousAccountOpenState = usePrevious(isAccountOpen)
   useEffect(() => {
     if (isAccountOpen === false && previousAccountOpenState === true) {

--- a/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
+++ b/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import Link from "next/link";
 import { Account } from "@/app/(app)/bridge/Account";
 import Bridge from "@/icons/bridge.svg";
@@ -32,7 +32,8 @@ import { QueryTransactionList, LocalStorageTransactionList } from "./transaction
 
 export const WalletSheet = () => {
   const transactionState = useStore(useTransactionManager, (state) => state);
-  const allTransactionsProcessed = transactionState?.allTransacationsProcessed;
+  const newTransactionCount = transactionState?.newTransactionCount;
+
   const {
     isConnected: isL2Connected,
     chainId,
@@ -42,7 +43,26 @@ export const WalletSheet = () => {
   const isStarknetWrongNetwork = isL2Connected &&
     chainId !== undefined && BigInt(chainId) !== chain.id;
 
+
   const { isAccountOpen, toggleAccount } = useUIStore((state) => state);
+
+
+
+  function usePrevious(isAccountOpen: boolean) {
+    const ref = useRef<boolean>();
+    useEffect(() => {
+      ref.current = isAccountOpen; //assign the value of ref to the argument
+    }, [isAccountOpen]); //this code will run when the value of 'value' changes
+    return ref.current; //in the end, return the current ref value.
+  }
+
+
+  const previousAccountOpenState = usePrevious(isAccountOpen)
+  useEffect(() => {
+    if (isAccountOpen === false && previousAccountOpenState === true) {
+      transactionState?.resetTransacationCount()
+    }
+  }, [isAccountOpen])
 
   const tabs = [
     {
@@ -127,7 +147,7 @@ export const WalletSheet = () => {
                 </Dialog>
               </div>
             </div>
-            {allTransactionsProcessed ? <LocalStorageTransactionList /> : <QueryTransactionList />}
+            {newTransactionCount && newTransactionCount > 0 ? <QueryTransactionList /> : <LocalStorageTransactionList />}
           </div>
         </SheetContent>
       </Sheet>

--- a/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
+++ b/apps/nextjs/src/app/_components/wallet/WalletSheet.tsx
@@ -43,10 +43,7 @@ export const WalletSheet = () => {
   const isStarknetWrongNetwork = isL2Connected &&
     chainId !== undefined && BigInt(chainId) !== chain.id;
 
-
   const { isAccountOpen, toggleAccount } = useUIStore((state) => state);
-
-
 
   function usePrevious(isAccountOpen: boolean) {
     const ref = useRef<boolean>();
@@ -57,6 +54,7 @@ export const WalletSheet = () => {
   }
 
 
+  //after user closes wallet sheet, reset transactions and transactioncount in localstorage
   const previousAccountOpenState = usePrevious(isAccountOpen)
   useEffect(() => {
     if (isAccountOpen === false && previousAccountOpenState === true) {

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
@@ -25,6 +25,7 @@ export const TransactionAction = ({ tx }: { tx: CombinedTransaction }) => {
         l2Address: tx.l2Sender,
         tokenIds,
       }));
+    console.log(tx)
     if (txHash) {
       transactions?.addTx({
         hash: txHash,

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
@@ -31,7 +31,7 @@ export const TransactionAction = ({ tx }: { tx: CombinedTransaction }) => {
         type: TransactionType.BRIDGE_REALMS_L2_TO_L1_CONFIRM,
         chainId: SUPPORTED_L2_CHAIN_ID,
         status: "complete",
-        timestamp: new Date().getTime(),
+        timestamp: new Date(Date.now())
       });
       toast({
         title: TransactionType.BRIDGE_REALMS_L2_TO_L1_CONFIRM,

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
@@ -10,7 +10,7 @@ import { Loader } from "lucide-react";
 import { Button, toast } from "@realms-world/ui";
 
 export const TransactionAction = ({ tx }: { tx: CombinedTransaction }) => {
-  const { writeAsync, isPending } = useWriteFinalizeWithdrawRealms();
+  const { writeAsync, isPending, isSuccess } = useWriteFinalizeWithdrawRealms();
   const transactions = useStore(useTransactionManager, (state) => state);
   const finalizeWithdraw = useCallback(async () => {
     const tokenIds = tx.withdrawalEvents?.[0]?.tokenIds;
@@ -26,9 +26,9 @@ export const TransactionAction = ({ tx }: { tx: CombinedTransaction }) => {
         tokenIds,
       }));
     console.log(tx)
-    if (txHash) {
+    if (isSuccess) {
       transactions?.addTx({
-        hash: txHash,
+        hash: txHash || '',
         type: TransactionType.BRIDGE_REALMS_L2_TO_L1_CONFIRM,
         chainId: SUPPORTED_L2_CHAIN_ID,
         status: "complete",
@@ -36,7 +36,7 @@ export const TransactionAction = ({ tx }: { tx: CombinedTransaction }) => {
       });
       toast({
         title: TransactionType.BRIDGE_REALMS_L2_TO_L1_CONFIRM,
-        description: `${tokenIds.length} Realms are being withdrawn to your L1 wallet`,
+        description: `${tokenIds?.length} Realms are being withdrawn to your L1 wallet`,
       });
     }
   }, [writeAsync, transactions, tx]);

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
@@ -1,4 +1,4 @@
-import type { CombinedTransaction } from "@/hooks/useTransactions";
+import type { CombinedTransaction } from "@/stores/useTransasctionManager";
 import { useCallback } from "react";
 import { SUPPORTED_L2_CHAIN_ID } from "@/constants/env";
 import { TransactionType } from "@/constants/transactions";

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionAction.tsx
@@ -10,7 +10,7 @@ import { Loader } from "lucide-react";
 import { Button, toast } from "@realms-world/ui";
 
 export const TransactionAction = ({ tx }: { tx: CombinedTransaction }) => {
-  const { writeAsync, isPending, isSuccess } = useWriteFinalizeWithdrawRealms();
+  const { writeAsync, isPending } = useWriteFinalizeWithdrawRealms();
   const transactions = useStore(useTransactionManager, (state) => state);
   const finalizeWithdraw = useCallback(async () => {
     const tokenIds = tx.withdrawalEvents?.[0]?.tokenIds;
@@ -25,8 +25,7 @@ export const TransactionAction = ({ tx }: { tx: CombinedTransaction }) => {
         l2Address: tx.l2Sender,
         tokenIds,
       }));
-    console.log(tx)
-    if (isSuccess) {
+    if (txHash) {
       transactions?.addTx({
         hash: txHash || '',
         type: TransactionType.BRIDGE_REALMS_L2_TO_L1_CONFIRM,

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionItem.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionItem.tsx
@@ -1,5 +1,4 @@
-import type { CombinedTransaction } from "@/hooks/useTransactions";
-import type { Transaction } from "@/stores/useTransasctionManager";
+import type { CombinedTransaction } from "@/stores/useTransasctionManager";
 import { SUPPORTED_L2_CHAIN_ID } from "@/constants/env";
 import { TransactionType } from "@/constants/transactions";
 

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionList.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionList.tsx
@@ -9,7 +9,7 @@ import { useEffect } from "react";
 export const QueryTransactionList = () => {
   const { transactions } = useTransactions();
   const transactionState = useStore(useTransactionManager, (state) => state);
-  // after useTransactions fires, update stored transactions in localstorage that useTransactions returns
+  // after useTransactions fires, update stored combinedtransactions in localstorage
   useEffect(() => {
     transactionState?.updateCombinedTransactions(transactions);
   }, [transactions]);

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionList.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionList.tsx
@@ -1,16 +1,31 @@
 import { useTransactions } from "@/hooks/useTransactions";
-
+import { useLocalStorageTransactions } from "@/hooks/useLocalStorageTransactions";
 import { ScrollArea } from "@realms-world/ui";
-
 import { TransactionItem } from "./TransactionItem";
 
-export const TransactionList = () => {
+
+export const QueryTransactionList = () => {
   const { transactions } = useTransactions();
   return (
     <div className="mt-2 flex h-full w-full flex-grow flex-col border-b p-2">
       <span className="mb-2 font-sans text-sm">Transactions</span>
       <ScrollArea className="pr-2 [&>[data-radix-scroll-area-viewport]]:max-h-[500px]">
-        {transactions.map((tx, index) => {
+        {transactions?.map((tx, index) => {
+          return <TransactionItem tx={tx} key={tx.hash + index} />;
+        })}
+      </ScrollArea>
+    </div>
+  );
+};
+
+
+export const LocalStorageTransactionList = () => {
+  const { transactions } = useLocalStorageTransactions();
+  return (
+    <div className="mt-2 flex h-full w-full flex-grow flex-col border-b p-2">
+      <span className="mb-2 font-sans text-sm">Transactions</span>
+      <ScrollArea className="pr-2 [&>[data-radix-scroll-area-viewport]]:max-h-[500px]">
+        {transactions?.map((tx, index) => {
           return <TransactionItem tx={tx} key={tx.hash + index} />;
         })}
       </ScrollArea>

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionList.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionList.tsx
@@ -2,10 +2,16 @@ import { useTransactions } from "@/hooks/useTransactions";
 import { useLocalStorageTransactions } from "@/hooks/useLocalStorageTransactions";
 import { ScrollArea } from "@realms-world/ui";
 import { TransactionItem } from "./TransactionItem";
-
+import useStore from "@/hooks/useStore";
+import { useTransactionManager } from "@/stores/useTransasctionManager";
+import { useEffect } from "react";
 
 export const QueryTransactionList = () => {
   const { transactions } = useTransactions();
+  const transactionState = useStore(useTransactionManager, (state) => state);
+  useEffect(() => {
+    transactionState?.updateCombinedTransactions(transactions);
+  }, [transactions]);
   return (
     <div className="mt-2 flex h-full w-full flex-grow flex-col border-b p-2">
       <span className="mb-2 font-sans text-sm">Transactions</span>

--- a/apps/nextjs/src/app/_components/wallet/transactions/TransactionList.tsx
+++ b/apps/nextjs/src/app/_components/wallet/transactions/TransactionList.tsx
@@ -9,6 +9,7 @@ import { useEffect } from "react";
 export const QueryTransactionList = () => {
   const { transactions } = useTransactions();
   const transactionState = useStore(useTransactionManager, (state) => state);
+  // after useTransactions fires, update stored transactions in localstorage that useTransactions returns
   useEffect(() => {
     transactionState?.updateCombinedTransactions(transactions);
   }, [transactions]);
@@ -26,6 +27,7 @@ export const QueryTransactionList = () => {
 
 
 export const LocalStorageTransactionList = () => {
+  // if newTransactioncount is 0, use localstorage transactions instead
   const { transactions } = useLocalStorageTransactions();
   return (
     <div className="mt-2 flex h-full w-full flex-grow flex-col border-b p-2">

--- a/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
+++ b/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
@@ -33,13 +33,16 @@ const query = `query Withdrawals(
   }
   `;
 
-export const usePendingRealmsWithdrawals = ({
-  address,
-  status,
-}: {
-  address?: string;
-  status?: TransactionFinalityStatus;
-}) => {
+export const usePendingRealmsWithdrawals = (
+  {
+    address,
+    status,
+  }: {
+    address?: string;
+    status?: TransactionFinalityStatus;
+  },
+  transactionsProcessed: boolean | undefined,
+) => {
   const variables: { l1Address?: string; status?: string[] } = {};
   if (address) {
     variables.l1Address = address.toLowerCase();
@@ -67,6 +70,6 @@ export const usePendingRealmsWithdrawals = ({
           return res.data?.withdrawals;
         }),
     enabled: !!address,
-    refetchInterval: 20000,
+    refetchInterval: transactionsProcessed === false ? 20000 : false,
   });
 };

--- a/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
+++ b/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
@@ -51,7 +51,7 @@ export const usePendingRealmsWithdrawals = (
   if (status) {
     variables.status = [status];
   } else {
-    variables.status = ["ACCEPTED_ON_L1"];
+    variables.status = ["ACCEPTED_ON_L1", "FINISHED"];
   }
   console.log(address);
   return useQuery({

--- a/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
+++ b/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
@@ -43,6 +43,7 @@ export const usePendingRealmsWithdrawals = (
   },
   allTransactionsProcessed?: boolean,
 ) => {
+  console.log(status);
   const variables: { l1Address?: string; status?: string[] } = {};
   if (address) {
     variables.l1Address = address.toLowerCase();
@@ -50,8 +51,9 @@ export const usePendingRealmsWithdrawals = (
   if (status) {
     variables.status = [status];
   } else {
-    variables.status = ["ACCEPTED_ON_L1", "FINISHED"];
+    variables.status = ["ACCEPTED_ON_L1"];
   }
+  console.log(address);
   return useQuery({
     queryKey: ["pendingRealmsWithdrawals" + address + status],
     queryFn: async () =>

--- a/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
+++ b/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
@@ -41,7 +41,7 @@ export const usePendingRealmsWithdrawals = (
     address?: string;
     status?: TransactionFinalityStatus;
   },
-  transactionsProcessed: boolean | undefined,
+  allTransactionsProcessed?: boolean,
 ) => {
   const variables: { l1Address?: string; status?: string[] } = {};
   if (address) {
@@ -70,6 +70,6 @@ export const usePendingRealmsWithdrawals = (
           return res.data?.withdrawals;
         }),
     enabled: !!address,
-    refetchInterval: transactionsProcessed === false ? 20000 : false,
+    refetchInterval: allTransactionsProcessed === false ? 20000 : false,
   });
 };

--- a/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
+++ b/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
@@ -1,3 +1,4 @@
+import type { TransactionState } from "@/stores/useTransasctionManager";
 import type { RealmsWithdrawal } from "@/types/subgraph";
 import type { TransactionFinalityStatus } from "starknet";
 import { useQuery } from "@tanstack/react-query";
@@ -43,7 +44,6 @@ export const usePendingRealmsWithdrawals = (
   },
   allTransactionsProcessed?: boolean,
 ) => {
-  console.log(status);
   const variables: { l1Address?: string; status?: string[] } = {};
   if (address) {
     variables.l1Address = address.toLowerCase();
@@ -53,7 +53,7 @@ export const usePendingRealmsWithdrawals = (
   } else {
     variables.status = ["ACCEPTED_ON_L1", "FINISHED"];
   }
-  console.log(address);
+
   return useQuery({
     queryKey: ["pendingRealmsWithdrawals" + address + status],
     queryFn: async () =>

--- a/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
+++ b/apps/nextjs/src/hooks/bridge/data/usePendingRealmsWithdrawals.ts
@@ -1,4 +1,3 @@
-import type { TransactionState } from "@/stores/useTransasctionManager";
 import type { RealmsWithdrawal } from "@/types/subgraph";
 import type { TransactionFinalityStatus } from "starknet";
 import { useQuery } from "@tanstack/react-query";
@@ -34,16 +33,13 @@ const query = `query Withdrawals(
   }
   `;
 
-export const usePendingRealmsWithdrawals = (
-  {
-    address,
-    status,
-  }: {
-    address?: string;
-    status?: TransactionFinalityStatus;
-  },
-  allTransactionsProcessed?: boolean,
-) => {
+export const usePendingRealmsWithdrawals = ({
+  address,
+  status,
+}: {
+  address?: string;
+  status?: TransactionFinalityStatus;
+}) => {
   const variables: { l1Address?: string; status?: string[] } = {};
   if (address) {
     variables.l1Address = address.toLowerCase();
@@ -72,6 +68,5 @@ export const usePendingRealmsWithdrawals = (
           return res.data?.withdrawals;
         }),
     enabled: !!address,
-    refetchInterval: allTransactionsProcessed === false ? 20000 : false,
   });
 };

--- a/apps/nextjs/src/hooks/useLocalStorageTransactions.ts
+++ b/apps/nextjs/src/hooks/useLocalStorageTransactions.ts
@@ -1,0 +1,10 @@
+import { useMemo } from "react";
+import useStore from "@/hooks/useStore";
+import { useTransactionManager } from "@/stores/useTransasctionManager";
+
+export const useLocalStorageTransactions = () => {
+  const transactionState = useStore(useTransactionManager, (state) => state);
+  return {
+    transactions: transactionState?.combinedTransactions,
+  };
+};

--- a/apps/nextjs/src/hooks/useLocalStorageTransactions.ts
+++ b/apps/nextjs/src/hooks/useLocalStorageTransactions.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import useStore from "@/hooks/useStore";
 import { useTransactionManager } from "@/stores/useTransasctionManager";
 

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -34,21 +34,21 @@ export const useTransactions = () => {
   const { address } = useAccount();
   const { address: l2Address } = useStarknetAccount();
 
-  // grabs all pending realm withdrawals with status of accepted_on_l1
+  // grabs all pending realm withdrawals
   const { data: pendingWithdrawals } = usePendingRealmsWithdrawals(
     { address },
     allTransactionsProcessed,
   );
 
+  // finds all of the finishedWithdrawals
   const finishedWithdrawals = pendingWithdrawals?.map((withdrawal) => {
     if (withdrawal.withdrawalEvents[0]?.status === "FINISHED") {
       return withdrawal;
     }
   });
 
-  // grabs all pending realms withdrawals if status is finished.
   // executes if the user does not have all of their finished transactions already stored in local storage.
-  // or if user has a new finished transaction that is not yet in localstorage
+  // or if user has a finished transaction that is not yet in localstorage
   if (!finishedRealmsWithdrawalsProcessed) {
     console.log(finishedWithdrawals);
     finishedWithdrawals?.forEach((withdrawal, i) => {
@@ -60,7 +60,6 @@ export const useTransactions = () => {
         timestamp: new Date(Number(withdrawal?.createdTimestamp ?? 0n) * 1000),
       };
       if (!transactions?.includes(finishedTransaction)) {
-        console.log(finishedTransaction);
         transactionState?.addTx(finishedTransaction);
       }
       if (i === finishedWithdrawals?.length - 1) {
@@ -84,8 +83,6 @@ export const useTransactions = () => {
     },
   );
 
-  console.log(pendingWithdrawals);
-  //console.log(l2BridgeTransactions);
   const l2TransactionsMap = useMemo(() => {
     const map = new Map<
       bigint,

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -1,6 +1,6 @@
 import type { Transaction } from "@/stores/useTransasctionManager";
 import type { RealmsWithdrawal, RealmsWithdrawalEvent } from "@/types/subgraph";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { SUPPORTED_L1_CHAIN_ID, SUPPORTED_L2_CHAIN_ID } from "@/constants/env";
 import {
   BridgeTransactionType,
@@ -26,7 +26,7 @@ export interface CombinedTransaction
 export const useTransactions = () => {
   const transactionState = useStore(useTransactionManager, (state) => state);
   const transactions = transactionState?.transactions;
-  // const transactionsProcessed = transactionState?.allTransacationsProcessed;
+  const transactionsProcessed = transactionState?.allTransacationsProcessed;
 
   const { address } = useAccount();
   const { address: l2Address } = useStarknetAccount();
@@ -67,6 +67,7 @@ export const useTransactions = () => {
         },
       ]),
     );
+
     pendingWithdrawals?.forEach((withdrawal) => {
       if (withdrawal.req_hash) {
         const matchingTransaction = map.get(withdrawal.req_hash);
@@ -113,6 +114,7 @@ export const useTransactions = () => {
       }),
     );
     // Add transactions to the map, deduplicating by hash
+
     transactionsArray.forEach((tx) => {
       if (tx.hash && !transactionsMap.has(tx.hash)) {
         transactionsMap.set(tx.hash, tx);
@@ -141,7 +143,10 @@ export const useTransactions = () => {
     return deduplicatedArray;
   }, [l2TransactionsMap, transactions]);
 
-  transactionState?.updateAllTransacationsProcessed;
+  useEffect(() => {
+    transactionState?.updateAllTransacationsProcessed();
+  }, [combinedTransactions]);
+
   return {
     transactions: combinedTransactions,
   };

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -27,11 +27,15 @@ export const useTransactions = () => {
   const transactionState = useStore(useTransactionManager, (state) => state);
   const transactions = transactionState?.transactions;
   const transactionsProcessed = transactionState?.allTransacationsProcessed;
+  console.log(transactionsProcessed);
 
   const { address } = useAccount();
   const { address: l2Address } = useStarknetAccount();
 
-  const { data: pendingWithdrawals } = usePendingRealmsWithdrawals({ address });
+  const { data: pendingWithdrawals } = usePendingRealmsWithdrawals(
+    { address },
+    transactionsProcessed,
+  );
 
   const filters: RouterInputs["erc721Bridge"]["all"] = useMemo(
     () => ({
@@ -43,7 +47,7 @@ export const useTransactions = () => {
   const { data: l2BridgeTransactions } = api.erc721Bridge.all.useQuery(
     filters,
     {
-      refetchInterval: 30000,
+      refetchInterval: transactionsProcessed === false ? 20000 : false,
       enabled: !!address || !!l2Address,
     },
   );

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -36,18 +36,21 @@ export const useTransactions = () => {
 
   // grabs all pending realm withdrawals with status of accepted_on_l1
   const { data: pendingWithdrawals } = usePendingRealmsWithdrawals(
-    { address: address, status: "ACCEPTED_ON_L1" },
+    { address },
     allTransactionsProcessed,
   );
+
+  const finishedWithdrawals = pendingWithdrawals?.map((withdrawal) => {
+    if (withdrawal.withdrawalEvents[0]?.status === "FINISHED") {
+      return withdrawal;
+    }
+  });
 
   // grabs all pending realms withdrawals if status is finished.
   // executes if the user does not have all of their finished transactions already stored in local storage.
   // or if user has a new finished transaction that is not yet in localstorage
   if (!finishedRealmsWithdrawalsProcessed) {
-    const { data: finishedWithdrawals } = usePendingRealmsWithdrawals(
-      { address: address, status: "FINISHED" },
-      allTransactionsProcessed,
-    );
+    console.log(finishedWithdrawals);
     finishedWithdrawals?.forEach((withdrawal, i) => {
       let finishedTransaction: Transaction = {
         status: "complete",
@@ -57,6 +60,7 @@ export const useTransactions = () => {
         timestamp: new Date(Number(withdrawal?.createdTimestamp ?? 0n) * 1000),
       };
       if (!transactions?.includes(finishedTransaction)) {
+        console.log(finishedTransaction);
         transactionState?.addTx(finishedTransaction);
       }
       if (i === finishedWithdrawals?.length - 1) {

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -26,15 +26,14 @@ export interface CombinedTransaction
 export const useTransactions = () => {
   const transactionState = useStore(useTransactionManager, (state) => state);
   const transactions = transactionState?.transactions;
-  const transactionsProcessed = transactionState?.allTransacationsProcessed;
-  console.log(transactionsProcessed);
+  const allTransactionsProcessed = transactionState?.allTransacationsProcessed;
 
   const { address } = useAccount();
   const { address: l2Address } = useStarknetAccount();
 
   const { data: pendingWithdrawals } = usePendingRealmsWithdrawals(
     { address },
-    transactionsProcessed,
+    allTransactionsProcessed,
   );
 
   const filters: RouterInputs["erc721Bridge"]["all"] = useMemo(
@@ -47,7 +46,7 @@ export const useTransactions = () => {
   const { data: l2BridgeTransactions } = api.erc721Bridge.all.useQuery(
     filters,
     {
-      refetchInterval: transactionsProcessed === false ? 20000 : false,
+      refetchInterval: allTransactionsProcessed === false ? 20000 : false,
       enabled: !!address || !!l2Address,
     },
   );

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -147,8 +147,10 @@ export const useTransactions = () => {
   }, [l2TransactionsMap, transactions]);
 
   useEffect(() => {
-    transactionState?.updateAllTransacationsProcessed();
-  }, [combinedTransactions]);
+    if (allTransactionsProcessed === false) {
+      transactionState?.updateAllTransacationsProcessed();
+    }
+  }, [allTransactionsProcessed, transactionState, combinedTransactions]);
 
   return {
     transactions: combinedTransactions,

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -20,16 +20,12 @@ import { padAddress } from "@realms-world/utils";
 export const useTransactions = () => {
   const transactionState = useStore(useTransactionManager, (state) => state);
   const transactions = transactionState?.transactions;
-  const allTransactionsProcessed = transactionState?.allTransacationsProcessed;
 
   const { address } = useAccount();
   const { address: l2Address } = useStarknetAccount();
 
   // grabs all pending realm withdrawals
-  const { data: pendingWithdrawals } = usePendingRealmsWithdrawals(
-    { address },
-    allTransactionsProcessed,
-  );
+  const { data: pendingWithdrawals } = usePendingRealmsWithdrawals({ address });
 
   const filters: RouterInputs["erc721Bridge"]["all"] = useMemo(
     () => ({
@@ -41,7 +37,6 @@ export const useTransactions = () => {
   const { data: l2BridgeTransactions } = api.erc721Bridge.all.useQuery(
     filters,
     {
-      refetchInterval: allTransactionsProcessed === false ? 20000 : false,
       enabled: !!address || !!l2Address,
     },
   );
@@ -112,7 +107,6 @@ export const useTransactions = () => {
       }),
     );
     // Add transactions to the map, deduplicating by hash
-
     transactionsArray.forEach((tx) => {
       if (tx.hash && !transactionsMap.has(tx.hash)) {
         transactionsMap.set(tx.hash, tx);
@@ -140,12 +134,6 @@ export const useTransactions = () => {
 
     return deduplicatedArray;
   }, [l2TransactionsMap, transactions]);
-
-  useEffect(() => {
-    if (allTransactionsProcessed === false) {
-      transactionState?.updateAllTransacationsProcessed(combinedTransactions);
-    }
-  }, [allTransactionsProcessed, transactionState, combinedTransactions]);
 
   return {
     transactions: combinedTransactions,

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -51,6 +51,8 @@ export const useTransactions = () => {
     },
   );
 
+  console.log(pendingWithdrawals);
+  //console.log(l2BridgeTransactions);
   const l2TransactionsMap = useMemo(() => {
     const map = new Map<
       bigint,

--- a/apps/nextjs/src/hooks/useTransactions.ts
+++ b/apps/nextjs/src/hooks/useTransactions.ts
@@ -72,6 +72,7 @@ export const useTransactions = () => {
     );
 
     pendingWithdrawals?.forEach((withdrawal) => {
+      console.log(map);
       if (withdrawal.req_hash) {
         const matchingTransaction = map.get(withdrawal.req_hash);
         if (matchingTransaction) {

--- a/apps/nextjs/src/stores/useTransasctionManager.ts
+++ b/apps/nextjs/src/stores/useTransasctionManager.ts
@@ -25,8 +25,8 @@ export interface TransactionState {
   transactions: Transaction[];
   combinedTransactions: CombinedTransaction[];
   addTx: (tx: Transaction) => void;
-  allTransacationsProcessed: boolean;
-  updateAllTransacationsProcessed: (
+  resetTransacationCount: () => void;
+  updateCombinedTransactions: (
     combinedTransactions: CombinedTransaction[],
   ) => void;
 }
@@ -41,6 +41,7 @@ export const useTransactionManager = create<
       combinedTransactions: [],
       newTransactionCount: 0,
       allTransacationsProcessed: false,
+
       addTx: (tx: Transaction) => {
         const paddedHash: string = isStarknetAddress(tx.hash)
           ? padAddress(tx.hash)
@@ -56,19 +57,19 @@ export const useTransactionManager = create<
           allTransacationsProcessed: false,
         }));
       },
-
-      updateAllTransacationsProcessed: (combinedTransactions) => {
+      resetTransacationCount: () => {
         return set((state) => ({
-          ...state,
-          allTransacationsProcessed: true,
           newTransactionCount: 0,
-          combinedTransactions: [...combinedTransactions],
+        }));
+      },
+      updateCombinedTransactions: (combinedTransactions) => {
+        return set((state) => ({
+          combinedTransactions: combinedTransactions,
         }));
       },
     }),
     {
-      name: "starknetTransactions", // unique name for localStorage key
-      //storage: createJSONStorage(() => localStorage),
+      name: "starknetTransactions",
     },
   ),
 );

--- a/apps/nextjs/src/stores/useTransasctionManager.ts
+++ b/apps/nextjs/src/stores/useTransasctionManager.ts
@@ -15,6 +15,7 @@ export interface Transaction {
 }
 
 interface TransactionState {
+  newTransactionCount: number;
   transactions: Transaction[];
   addTx: (tx: Transaction) => void;
   allTransacationsProcessed: boolean;
@@ -28,24 +29,26 @@ export const useTransactionManager = create<
   persist(
     (set) => ({
       transactions: [],
+      newTransactionCount: 0,
       allTransacationsProcessed: false,
       addTx: (tx: Transaction) => {
-        console.log(tx);
         const paddedHash: string = isStarknetAddress(tx.hash)
           ? padAddress(tx.hash)
           : tx.hash;
         const updatedTransaction = {
           ...tx,
           hash: paddedHash,
-          transactionDataFetched: true,
         };
         return set((state) => ({
           transactions: [...state.transactions, updatedTransaction],
+          newTransactionCount: state.newTransactionCount + 1,
+          allTransacationsProcessed: false,
         }));
       },
       updateAllTransacationsProcessed: () => {
         return set((state) => ({
-          allTransacationsProcessed: (state.allTransacationsProcessed = true),
+          allTransacationsProcessed: true,
+          newTransactionCount: 0,
         }));
       },
     }),

--- a/apps/nextjs/src/stores/useTransasctionManager.ts
+++ b/apps/nextjs/src/stores/useTransasctionManager.ts
@@ -18,8 +18,10 @@ interface TransactionState {
   newTransactionCount: number;
   transactions: Transaction[];
   addTx: (tx: Transaction) => void;
+  finishedRealmsWithdrawalsProcessed: boolean;
   allTransacationsProcessed: boolean;
   updateAllTransacationsProcessed: () => void;
+  updateFinishedRealmsWithdrawalsProcessed: () => void;
 }
 
 export const useTransactionManager = create<
@@ -30,6 +32,7 @@ export const useTransactionManager = create<
     (set) => ({
       transactions: [],
       newTransactionCount: 0,
+      finishedRealmsWithdrawalsProcessed: false,
       allTransacationsProcessed: false,
       addTx: (tx: Transaction) => {
         const paddedHash: string = isStarknetAddress(tx.hash)
@@ -39,10 +42,20 @@ export const useTransactionManager = create<
           ...tx,
           hash: paddedHash,
         };
+
         return set((state) => ({
           transactions: [...state.transactions, updatedTransaction],
           newTransactionCount: state.newTransactionCount + 1,
           allTransacationsProcessed: false,
+          finishedRealmsWithdrawalsProcessed:
+            updatedTransaction.type == "Finalise Realms Withdrawal to L1"
+              ? false
+              : true,
+        }));
+      },
+      updateFinishedRealmsWithdrawalsProcessed: () => {
+        return set((state) => ({
+          finishedRealmsWithdrawalsProcessed: true,
         }));
       },
       updateAllTransacationsProcessed: () => {

--- a/apps/nextjs/src/stores/useTransasctionManager.ts
+++ b/apps/nextjs/src/stores/useTransasctionManager.ts
@@ -17,6 +17,8 @@ export interface Transaction {
 interface TransactionState {
   transactions: Transaction[];
   addTx: (tx: Transaction) => void;
+  allTransacationsProcessed: boolean;
+  updateAllTransacationsProcessed: () => void;
 }
 
 export const useTransactionManager = create<
@@ -26,16 +28,24 @@ export const useTransactionManager = create<
   persist(
     (set) => ({
       transactions: [],
+      allTransacationsProcessed: false,
       addTx: (tx: Transaction) => {
+        console.log(tx);
         const paddedHash: string = isStarknetAddress(tx.hash)
           ? padAddress(tx.hash)
           : tx.hash;
         const updatedTransaction = {
           ...tx,
           hash: paddedHash,
+          transactionDataFetched: true,
         };
         return set((state) => ({
           transactions: [...state.transactions, updatedTransaction],
+        }));
+      },
+      updateAllTransacationsProcessed: () => {
+        return set((state) => ({
+          allTransacationsProcessed: (state.allTransacationsProcessed = true),
         }));
       },
     }),

--- a/apps/nextjs/src/stores/useTransasctionManager.ts
+++ b/apps/nextjs/src/stores/useTransasctionManager.ts
@@ -24,6 +24,7 @@ export interface TransactionState {
   newTransactionCount: number;
   transactions: Transaction[];
   combinedTransactions: CombinedTransaction[];
+  allTransactionsProcessed: boolean;
   addTx: (tx: Transaction) => void;
   resetTransacationCount: () => void;
   updateCombinedTransactions: (
@@ -40,8 +41,7 @@ export const useTransactionManager = create<
       transactions: [],
       combinedTransactions: [],
       newTransactionCount: 0,
-      allTransacationsProcessed: false,
-
+      allTransactionsProcessed: false,
       addTx: (tx: Transaction) => {
         const paddedHash: string = isStarknetAddress(tx.hash)
           ? padAddress(tx.hash)
@@ -52,13 +52,14 @@ export const useTransactionManager = create<
         };
 
         return set((state) => ({
+          allTransactionsProcessed: false,
           transactions: [...state.transactions, updatedTransaction],
           newTransactionCount: state.newTransactionCount + 1,
-          allTransacationsProcessed: false,
         }));
       },
       resetTransacationCount: () => {
         return set((state) => ({
+          allTransactionsProcessed: true,
           newTransactionCount: 0,
         }));
       },


### PR DESCRIPTION
stores `combinedTransactions` in localstorage after useTransactions initially fires.

Creates `QueryTransactionList` and `LocalStorageTransactionList` components for wallet sheet to toggle between the two if `newTransactionCount` is greater than 0.

removes refetchinterval from queries in usetransactions 

Adds a count icon to the starknet wallet button if a new transaction has been completed by the user and the user has not opened their wallet sheet.
