### PR TITLE
Restyle account portal with Realms theme

### DIFF
--- a/apps/account-portal/src/components/layout/app-sidebar.tsx
+++ b/apps/account-portal/src/components/layout/app-sidebar.tsx
@@ -13,7 +13,6 @@ import {
   Castle,
   ClipboardPen,
   ExternalLink,
-  HandCoins,
   Vote,
 } from "lucide-react";
 
@@ -36,7 +35,7 @@ const data = {
         {
           title: "Eternum Season Passes",
           target: "_blank",
-          url: "https://empire.realms.world/season-passes",
+          url: "https://market.realms.world",
         },
       ],
     },
@@ -62,11 +61,6 @@ const data = {
           url: "#",
         },
       ],*/
-    },
-    {
-      title: "Claims",
-      url: "/realms/claims",
-      icon: HandCoins,
     },
   ],
 
@@ -135,15 +129,15 @@ const data = {
       items: [
         {
           title: "Realms.World",
-          url: "https://realmsworld.notion.site/",
+          url: "https://realms.world",
         },
         {
           title: "Eternum",
-          url: "https://eternum-docs.realms.world/",
+          url: "https://blitz.realms.world",
         },
         {
           title: "Developer",
-          url: "https://eternum-docs.realms.world/development",
+          url: "https://docs.realms.world",
         },
       ],
     },

--- a/apps/account-portal/src/components/layout/header.tsx
+++ b/apps/account-portal/src/components/layout/header.tsx
@@ -53,14 +53,14 @@ export function Header() {
   return (
     <header
       className={cn(
-        "bg-sidebar sticky top-0 z-50 flex shrink-0 items-center border-b transition-[width,height] ease-linear",
+        "bg-sidebar/85 sticky top-0 z-50 flex shrink-0 items-center border-b border-[color:var(--realm-border-strong)] backdrop-blur-xl transition-[width,height] ease-linear",
       )}
     >
-      <div className="h-(--header-height) flex w-full gap-2">
+      <div className="flex h-(--header-height) w-full gap-2">
         <div
           className={
-            `${open ? "sm:w-(--sidebar-width) w-16 px-1" : "w-(--sidebar-width-icon)"}` +
-            " flex items-center justify-center border-r"
+            `${open ? "w-16 px-1 sm:w-(--sidebar-width)" : "w-(--sidebar-width-icon)"}` +
+            " flex items-center justify-center border-r border-[color:var(--realm-border-strong)]"
           }
         >
           <Link to="/">
@@ -85,7 +85,7 @@ export function Header() {
                 <Button
                   variant="outline"
                   size="lg"
-                  className="flex items-center gap-2 rounded px-3"
+                  className="flex items-center gap-2 rounded-xl px-3"
                 >
                   <img className="w-7" src={getConnectorIcon(connector)} />
                   {shortenAddress(address)}
@@ -99,9 +99,7 @@ export function Header() {
                         src={`https://api.dicebear.com/6.x/bottts-neutral/svg?seed=${address}`}
                       />
                     </Avatar>
-                    <div className="text-xl">
-                      {shortenAddress(address)}
-                    </div>
+                    <div className="text-xl">{shortenAddress(address)}</div>
                   </div>
                   <div className="flex items-center gap-2">
                     <a

--- a/apps/account-portal/src/components/layout/login-card.tsx
+++ b/apps/account-portal/src/components/layout/login-card.tsx
@@ -67,7 +67,7 @@ function FeatureItem({
     <div className="realm-subtle-panel flex items-start gap-3 rounded-2xl p-4">
       <div className="text-2xl">{icon}</div>
       <div>
-        <h3 className="font-display text-sm font-semibold tracking-[0.12em] uppercase">
+        <h3 className="font-display text-sm font-semibold tracking-[var(--tracking-card)] uppercase">
           {title}
         </h3>
         <p className="text-muted-foreground text-sm">{description}</p>

--- a/apps/account-portal/src/components/layout/login-card.tsx
+++ b/apps/account-portal/src/components/layout/login-card.tsx
@@ -12,6 +12,7 @@ export function LoginCard() {
   return (
     <Card className="mx-auto mt-12 w-full max-w-lg">
       <CardHeader>
+        <p className="realm-eyebrow text-center">Enter The Realm</p>
         <CardTitle className="text-center text-2xl">
           Welcome to Realms Portal
         </CardTitle>
@@ -63,10 +64,12 @@ function FeatureItem({
   icon: string;
 }) {
   return (
-    <div className="flex items-start gap-3">
+    <div className="realm-subtle-panel flex items-start gap-3 rounded-2xl p-4">
       <div className="text-2xl">{icon}</div>
       <div>
-        <h3 className="font-medium">{title}</h3>
+        <h3 className="font-display text-sm font-semibold tracking-[0.12em] uppercase">
+          {title}
+        </h3>
         <p className="text-muted-foreground text-sm">{description}</p>
       </div>
     </div>

--- a/apps/account-portal/src/components/layout/login-card.tsx
+++ b/apps/account-portal/src/components/layout/login-card.tsx
@@ -10,45 +10,35 @@ import { StarknetWalletButton } from "./starknet-wallet-button";
 
 export function LoginCard() {
   return (
-    <Card className="mx-auto mt-12 w-full max-w-lg">
-      <CardHeader>
-        <p className="realm-eyebrow text-center">Enter The Realm</p>
-        <CardTitle className="text-center text-2xl">
-          Welcome to Realms Portal
-        </CardTitle>
-        <CardDescription className="text-center">
+    <Card className="mx-auto mt-12 w-full max-w-md">
+      <CardHeader className="pb-2 text-center">
+        <p className="realm-eyebrow">Enter The Realm</p>
+        <CardTitle className="text-2xl">Welcome to Realms Portal</CardTitle>
+        <CardDescription>
           Connect your wallet to access the Realms ecosystem
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-6">
-        {/* Feature list */}
-        <div className="space-y-4">
+      <CardContent className="space-y-5">
+        <div className="space-y-3">
           <FeatureItem
             title="Bridge Assets"
-            description="Transfer your assets seamlessly between Ethereum and StarkNet"
-            icon="🌉"
+            description="Transfer assets between Ethereum and StarkNet"
           />
           <FeatureItem
             title="LORDS Claiming"
             description="Claim and manage your LORDS tokens"
-            icon="👑"
           />
           <FeatureItem
             title="veLORDS Staking"
-            description="Stake your LORDS to earn rewards and voting power"
-            icon="⚡"
+            description="Stake LORDS to earn rewards and voting power"
           />
           <FeatureItem
             title="Governance"
             description="Participate in shaping the future of Realms"
-            icon="🏛️"
           />
         </div>
 
-        {/* Connect wallet button */}
-        <div className="w-full pt-4">
-          <StarknetWalletButton className="w-full" variant="reference" />
-        </div>
+        <StarknetWalletButton className="w-full" variant="reference" />
       </CardContent>
     </Card>
   );
@@ -57,20 +47,18 @@ export function LoginCard() {
 function FeatureItem({
   title,
   description,
-  icon,
 }: {
   title: string;
   description: string;
-  icon: string;
 }) {
   return (
-    <div className="realm-subtle-panel flex items-start gap-3 rounded-2xl p-4">
-      <div className="text-2xl">{icon}</div>
+    <div className="flex items-baseline gap-2 px-1">
+      <span className="text-primary text-xs">&#x25C6;</span>
       <div>
         <h3 className="font-display text-sm font-semibold tracking-[var(--tracking-card)] uppercase">
           {title}
         </h3>
-        <p className="text-muted-foreground text-sm">{description}</p>
+        <p className="text-muted-foreground text-xs">{description}</p>
       </div>
     </div>
   );

--- a/apps/account-portal/src/components/layout/page-header.tsx
+++ b/apps/account-portal/src/components/layout/page-header.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/utils";
+
+interface PageHeaderProps {
+  title: ReactNode;
+  eyebrow?: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({
+  title,
+  eyebrow,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between",
+        className,
+      )}
+    >
+      <div className="space-y-2">
+        {eyebrow ? <p className="realm-eyebrow">{eyebrow}</p> : null}
+        <h1 className="realm-page-title text-3xl sm:text-4xl">{title}</h1>
+        {description ? (
+          <p className="text-muted-foreground text-sm sm:text-base">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+    </div>
+  );
+}

--- a/apps/account-portal/src/components/layout/starknet-wallet-button.tsx
+++ b/apps/account-portal/src/components/layout/starknet-wallet-button.tsx
@@ -40,7 +40,7 @@ export const StarknetWalletButton = ({
   const isReferenceVariant = variant === "reference";
   const resolvedPickerMode = pickerMode ?? (variant === "reference" ? "sheet" : "dropdown");
   const pickerTriggerClassName = isReferenceVariant
-    ? "inline-flex h-9 w-9 items-center justify-center rounded-lg bg-background/40 text-foreground transition hover:bg-accent"
+    ? "inline-flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-accent hover:text-foreground"
     : "inline-flex h-7 w-7 items-center justify-center rounded-md text-primary-foreground/80 transition hover:bg-primary-foreground/10";
 
   const connectPrimary = () => {
@@ -108,7 +108,8 @@ export const StarknetWalletButton = ({
       <div className={cn("relative w-full", className)}>
         <Button
           onClick={connectPrimary}
-          className="h-14 w-full justify-start rounded-2xl border px-3 pr-16 shadow-sm"
+          variant="outline"
+          className="h-14 w-full justify-start rounded-2xl px-3 pr-16 shadow-sm"
         >
           <span className="mr-3 inline-flex h-6 w-6 items-center justify-center rounded-md bg-muted">
             {lastConnector ? (
@@ -118,10 +119,10 @@ export const StarknetWalletButton = ({
             )}
           </span>
           <span className="flex flex-col items-start leading-tight">
-            <span className="text-base font-semibold">
+            <span className="text-foreground text-base font-semibold">
               {label ?? "Connect wallet"}
             </span>
-            <span className="text-xs text-muted-foreground">
+            <span className="text-muted-foreground text-xs">
               {lastConnector
                 ? `Previously used ${lastConnector.name}`
                 : "Choose a Starknet wallet"}

--- a/apps/account-portal/src/components/modules/governance/delegate-card.tsx
+++ b/apps/account-portal/src/components/modules/governance/delegate-card.tsx
@@ -90,13 +90,13 @@ export function DelegateCard({
                 src={`https://cdn.stamp.fyi/avatar/${delegate.user}?s=64`}
               />
             </Avatar>
-            <h2 className="text-xl font-bold">{name}</h2>
+            <h2 className="text-xl">{name}</h2>
           </div>
           {isCurrentDelegate ? <Badge>Current Delegate</Badge> : null}
         </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-2">
-        <p className="text-xl">
+        <p className="realm-stat text-xl">
           {formatNumber(Number(delegate.delegatedVotes), 0)}{" "}
           <span className="text-muted-foreground text-sm uppercase">
             Votes Delegated

--- a/apps/account-portal/src/components/modules/governance/proposal-list-item.tsx
+++ b/apps/account-portal/src/components/modules/governance/proposal-list-item.tsx
@@ -46,7 +46,7 @@ export const ProposalListItem = ({
       >
         <div className="flex flex-col gap-2">
           <div className="flex flex-col gap-1">
-            <h4 className="line-clamp-2 text-lg font-semibold">
+            <h4 className="realm-card-title line-clamp-2">
               {proposal.metadata?.title ?? `Proposal #${proposal.id}`}
             </h4>
             <div className="text-muted-foreground text-sm">

--- a/apps/account-portal/src/components/modules/homepage/homepage.tsx
+++ b/apps/account-portal/src/components/modules/homepage/homepage.tsx
@@ -135,7 +135,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
           {/* Realms Card */}
           <Card>
             <CardHeader className="pb-4">
-              <CardTitle className="text-lg">Realms</CardTitle>
+              <CardTitle>Realms</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between">
@@ -185,7 +185,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
           {/* Lords Card */}
           <Card>
             <CardHeader className="pb-4">
-              <CardTitle className="flex items-center gap-2 text-lg">
+              <CardTitle className="flex items-center gap-2">
                 <LordsIcon className="h-6 w-6" />
                 Lords
               </CardTitle>
@@ -234,7 +234,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
           {/* Claims Section */}
           <Card>
             <CardHeader className="pb-4">
-              <CardTitle className="text-lg">Available Claims</CardTitle>
+              <CardTitle>Available Claims</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-4">
@@ -317,11 +317,11 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               (currentDelegate.user && BigInt(currentDelegate.user) === 0n) ? (
               <Card>
                 <CardHeader className="pb-4">
-                  <CardTitle className="text-lg">Governance</CardTitle>
+                  <CardTitle>Governance</CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className="text-center">
-                    <h3 className="mb-2 text-lg font-semibold">
+                    <h3 className="realm-card-title mb-2">
                       No Delegate Selected
                     </h3>
                     <p className="text-muted-foreground mb-4 text-sm">
@@ -364,7 +364,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
         {/* Proposals Section */}
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-4">
-            <CardTitle className="text-lg">Recent Proposals</CardTitle>
+            <CardTitle>Recent Proposals</CardTitle>
             <Link to={`/proposal/list`}>
               <Button variant="outline" size="sm">
                 View All
@@ -383,7 +383,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
           {accountTokens?.length > 0 ? (
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-4">
-                <CardTitle className="text-lg">Your Realms</CardTitle>
+                <CardTitle>Your Realms</CardTitle>
                 {accountTokens.length > 5 && (
                   <Link to={`/realms`}>
                     <Button variant="outline" size="sm">
@@ -424,7 +424,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
           ) : (
             <Card>
               <CardHeader className="pb-4">
-                <CardTitle className="text-lg">Your Realms</CardTitle>
+                <CardTitle>Your Realms</CardTitle>
               </CardHeader>
               <CardContent className="pb-6 text-center">
                 <div className="text-muted-foreground text-lg">

--- a/apps/account-portal/src/components/modules/homepage/homepage.tsx
+++ b/apps/account-portal/src/components/modules/homepage/homepage.tsx
@@ -1,3 +1,4 @@
+import type { RawTokenBalanceWithMetadata } from "@/lib/eternum/getPortfolioCollections";
 import type { Address } from "@starknet-start/react";
 import { Suspense } from "react";
 import { VeLords } from "@/abi/L2/VeLords";
@@ -20,7 +21,6 @@ import { useCurrentDelegate } from "@/hooks/governance/use-current-delegate";
 import { useL2RealmsClaims } from "@/hooks/use-l2-realms-claims";
 import useVeLordsClaims from "@/hooks/use-velords-claims";
 import { getAccountTokensQueryOptions } from "@/lib/eternum/getPortfolioCollections";
-import type { RawTokenBalanceWithMetadata } from "@/lib/eternum/getPortfolioCollections";
 import { getDelegateByIDQueryOptions } from "@/lib/getDelegates";
 import { getL1UsersRealmsQueryOptions } from "@/lib/getL1Realms";
 import {
@@ -41,7 +41,11 @@ import { num } from "starknet";
 import { formatEther } from "viem";
 import { useAccount as useL1Account, useBalance as useL1Balance } from "wagmi";
 
-import { CollectionAddresses, LORDS, StakingAddresses } from "@realms-world/constants";
+import {
+  CollectionAddresses,
+  LORDS,
+  StakingAddresses,
+} from "@realms-world/constants";
 
 import { ProposalList } from "../governance/proposal-list";
 
@@ -77,7 +81,9 @@ export function Homepage({ address }: { address: `0x${string}` }) {
 
   const { data } = useCurrentDelegate();
   const delegateAddress =
-    data && BigInt(data) !== 0n ? formatAddress(num.toHex(BigInt(data))) : undefined;
+    data && BigInt(data) !== 0n
+      ? formatAddress(num.toHex(BigInt(data)))
+      : undefined;
   const currentDelegateQuery = useQuery(
     getDelegateByIDQueryOptions({
       address: delegateAddress,
@@ -134,7 +140,9 @@ export function Homepage({ address }: { address: `0x${string}` }) {
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="text-3xl font-bold">{l1RealmCount}</div>
+                  <div className="realm-stat text-3xl font-bold">
+                    {l1RealmCount}
+                  </div>
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
                     <EthereumIcon className="h-4 w-4" />
                     Ethereum
@@ -143,7 +151,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               </div>
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="text-3xl font-bold">
+                  <div className="realm-stat text-3xl font-bold">
                     {accountTokens?.length ?? 0}
                   </div>
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
@@ -185,7 +193,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="text-3xl font-bold">
+                  <div className="realm-stat text-3xl font-bold">
                     {formatNumber(Number(l1Balance?.formatted ?? 0))}
                   </div>
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
@@ -196,7 +204,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               </div>
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="text-3xl font-bold">
+                  <div className="realm-stat text-3xl font-bold">
                     {formatNumber(Number(starknetBalance?.formatted))}
                   </div>
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
@@ -207,7 +215,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               </div>
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="text-3xl font-bold">
+                  <div className="realm-stat text-3xl font-bold">
                     {formatNumber(
                       Number(formatEther(BigInt(ownerLordsLock?.amount ?? 0))),
                     )}
@@ -231,7 +239,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
             <CardContent className="p-6">
               <div className="space-y-4">
                 <Link to={`/realms/claims`}>
-                  <div className="hover:bg-muted/50 group rounded-lg border p-4 transition-colors">
+                  <div className="realm-interactive-row group hover:bg-accent/70 rounded-lg p-4 transition-colors hover:border-[color:var(--realm-accent-brass)]">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
                         <LordsIcon className="h-6 w-6" />
@@ -242,7 +250,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                           </div>
                         </div>
                       </div>
-                      <div className="text-2xl font-bold">
+                      <div className="realm-stat text-2xl font-bold">
                         {l2RealmsBalance
                           ? formatNumber(Number(formatEther(l2RealmsBalance)))
                           : 0}
@@ -252,7 +260,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                 </Link>
 
                 <Link to={`/velords`}>
-                  <div className="hover:bg-muted/50 group rounded-lg border p-4 transition-colors">
+                  <div className="realm-interactive-row group hover:bg-accent/70 rounded-lg p-4 transition-colors hover:border-[color:var(--realm-accent-brass)]">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
                         <LordsIcon className="h-6 w-6" />
@@ -263,7 +271,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                           </div>
                         </div>
                       </div>
-                      <div className="text-2xl font-bold">
+                      <div className="realm-stat text-2xl font-bold">
                         {lordsClaimable
                           ? formatNumber(Number(formatEther(lordsClaimable)))
                           : 0}
@@ -331,13 +339,17 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                   user: currentDelegate.user,
                   delegateProfile: currentDelegate.delegateProfile
                     ? {
-                        twitter: currentDelegate.delegateProfile.twitter ?? undefined,
-                        github: currentDelegate.delegateProfile.github ?? undefined,
+                        twitter:
+                          currentDelegate.delegateProfile.twitter ?? undefined,
+                        github:
+                          currentDelegate.delegateProfile.github ?? undefined,
                         telegram:
                           currentDelegate.delegateProfile.telegram ?? undefined,
-                        discord: currentDelegate.delegateProfile.discord ?? undefined,
+                        discord:
+                          currentDelegate.delegateProfile.discord ?? undefined,
                         interests:
-                          currentDelegate.delegateProfile.interests ?? undefined,
+                          currentDelegate.delegateProfile.interests ??
+                          undefined,
                         statement: currentDelegate.delegateProfile.statement,
                       }
                     : undefined,
@@ -382,9 +394,15 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               </CardHeader>
               <CardContent>
                 <div className="grid gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-                  {accountTokens.slice(0, 5).map((realm: RawTokenBalanceWithMetadata) => (
-                    <RealmCard key={realm.token_id} token={realm} isGrid={true} />
-                  ))}
+                  {accountTokens
+                    .slice(0, 5)
+                    .map((realm: RawTokenBalanceWithMetadata) => (
+                      <RealmCard
+                        key={realm.token_id}
+                        token={realm}
+                        isGrid={true}
+                      />
+                    ))}
                   {accountTokens.length > 5 && (
                     <Card className="flex items-center justify-center">
                       <Link

--- a/apps/account-portal/src/components/modules/homepage/homepage.tsx
+++ b/apps/account-portal/src/components/modules/homepage/homepage.tsx
@@ -169,7 +169,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                 </Button>
               </Link>
               <a
-                href="https://empire.realms.world/trade/realms"
+                href="https://market.realms.world"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex-1"
@@ -434,7 +434,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                   Visit the marketplace to acquire your first Realm
                 </p>
                 <a
-                  href="https://empire.realms.world/trade/realms"
+                  href="https://market.realms.world"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mt-4 inline-block"

--- a/apps/account-portal/src/components/modules/homepage/homepage.tsx
+++ b/apps/account-portal/src/components/modules/homepage/homepage.tsx
@@ -129,7 +129,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
 
   return (
     <>
-      <div className="space-y-8">
+      <div className="space-y-6">
         {/* Assets Section */}
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           {/* Realms Card */}
@@ -161,7 +161,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                 </div>
               </div>
             </CardContent>
-            <CardFooter className="flex gap-2 pt-4">
+            <CardFooter className="flex gap-2 pt-2">
               <Link to={`/realms/bridge`} className="flex-1">
                 <Button variant="outline" size="sm" className="w-full">
                   <BridgeIcon className="mr-2 h-4 w-4" />
@@ -230,13 +230,13 @@ export function Homepage({ address }: { address: `0x${string}` }) {
         </div>
 
         {/* Main Content Grid */}
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
           {/* Claims Section */}
           <Card>
             <CardHeader className="pb-4">
               <CardTitle className="text-lg">Available Claims</CardTitle>
             </CardHeader>
-            <CardContent className="p-6">
+            <CardContent className="space-y-4">
               <div className="space-y-4">
                 <Link to={`/realms/claims`}>
                   <div className="realm-interactive-row group hover:bg-accent/70 rounded-lg p-4 transition-colors hover:border-[color:var(--realm-accent-brass)]">
@@ -319,7 +319,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                 <CardHeader className="pb-4">
                   <CardTitle className="text-lg">Governance</CardTitle>
                 </CardHeader>
-                <CardContent className="p-6">
+                <CardContent>
                   <div className="text-center">
                     <h3 className="mb-2 text-lg font-semibold">
                       No Delegate Selected
@@ -407,7 +407,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                     <Card className="flex items-center justify-center">
                       <Link
                         to={`/realms`}
-                        className="flex h-full w-full items-center justify-center p-6"
+                        className="flex h-full w-full items-center justify-center p-4"
                       >
                         <div className="text-center">
                           <Plus className="text-muted-foreground mx-auto h-8 w-8" />
@@ -426,7 +426,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               <CardHeader className="pb-4">
                 <CardTitle className="text-lg">Your Realms</CardTitle>
               </CardHeader>
-              <CardContent className="p-12 text-center">
+              <CardContent className="pb-6 text-center">
                 <div className="text-muted-foreground text-lg">
                   No Realms found in your wallet
                 </div>

--- a/apps/account-portal/src/components/modules/realms/bridge-sidebar.tsx
+++ b/apps/account-portal/src/components/modules/realms/bridge-sidebar.tsx
@@ -136,16 +136,16 @@ const BridgeSidebar: React.FC<BridgeSidebarProps> = ({
       variant="inset"
       className="top-(--header-height) h-[calc(100svh-var(--header-height))]!"
     >
-      <div className="flex items-center justify-end gap-2 text-sm">
-        Ethereum Wallet:
-        <EthereumConnect />
-      </div>
-      <SidebarSeparator className="mx-0 mt-2" />
-      <SidebarHeader>
-        <div className="border-b pb-2 text-xl">
+      <SidebarHeader className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground text-sm">Ethereum Wallet</span>
+          <EthereumConnect />
+        </div>
+        <SidebarSeparator className="mx-0" />
+        <h2 className="realm-card-title">
           Bridging {selectedRows.length} Realms to
           {selectedAsset === "Ethereum" ? " Starknet" : " Ethereum"}
-        </div>
+        </h2>
         <SidebarGroup>
           <div className="mb-4 flex flex-wrap gap-2">
             {selectedRows.map((row) => (
@@ -254,7 +254,7 @@ const BridgeSidebar: React.FC<BridgeSidebarProps> = ({
             asChild
             className="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground w-full text-sm"
           >
-            <CollapsibleTrigger className="bg-sidebar-accent h-10">
+            <CollapsibleTrigger className="h-10">
               Transaction History
               <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
             </CollapsibleTrigger>

--- a/apps/account-portal/src/components/modules/realms/claims.tsx
+++ b/apps/account-portal/src/components/modules/realms/claims.tsx
@@ -56,7 +56,7 @@ export const ClaimRewards = () => {
             <div className="flex flex-col gap-4">
               <div className="flex items-center gap-2">
                 <LordsIcon className="w-9" />
-                <span className="text-3xl font-bold">
+                <span className="realm-stat text-3xl font-bold">
                   {balance && formatNumber(Number(formatEther(balance)))}
                 </span>{" "}
                 claimable
@@ -73,7 +73,7 @@ export const ClaimRewards = () => {
           </CardContent>
         </Card>
         {/* Rewards Info Section */}
-        <Card className="relativeoverflow-hidden">
+        <Card className="relative overflow-hidden">
           <CardHeader>
             <CardTitle>Lords Rewards have ended!</CardTitle>
           </CardHeader>

--- a/apps/account-portal/src/components/modules/realms/claims.tsx
+++ b/apps/account-portal/src/components/modules/realms/claims.tsx
@@ -3,10 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useL2RealmsClaims } from "@/hooks/use-l2-realms-claims";
 import { getRealmsLordsClaimsQueryOptions } from "@/lib/getRealmsLordsClaims";
-import {
-  formatNumber,
-  shortenAddress,
-} from "@/utils/utils";
+import { formatNumber, shortenAddress } from "@/utils/utils";
 import { useAccount, useExplorer } from "@starknet-start/react";
 import { useQuery } from "@tanstack/react-query";
 import { ExternalLink } from "lucide-react";
@@ -43,7 +40,12 @@ export const ClaimRewards = () => {
 
   return (
     <div className="flex flex-col gap-6 p-6">
-      <h1 className="text-2xl font-bold">Past Realms Claims Dashboard</h1>
+      <div className="space-y-2">
+        <p className="realm-eyebrow">Realms</p>
+        <h1 className="realm-page-title text-3xl sm:text-4xl">
+          Past Realms Claims Dashboard
+        </h1>
+      </div>
       <div className="grid gap-6 sm:grid-cols-3">
         {/* Claim Rewards Section */}
         <Card className="relative overflow-hidden">

--- a/apps/account-portal/src/components/modules/velords/stake-lords.tsx
+++ b/apps/account-portal/src/components/modules/velords/stake-lords.tsx
@@ -112,7 +112,7 @@ export const StakeLords = () => {
       </CardHeader>
       {address ? <><div className="flex flex-col items-center sm:flex-row">
         <Card className="mt-4 sm:ml-8 sm:mt-0">
-          <CardContent className="flex items-center px-4 pb-0 pt-2 text-lg font-semibold md:text-2xl">
+          <CardContent className="realm-stat flex items-center px-4 pb-0 pt-2 text-lg font-semibold md:text-2xl">
             <LordsIcon className="mr-2 h-6 w-6" />
             {formatNumber(availableLords)}
           </CardContent>

--- a/apps/account-portal/src/components/ui/button.tsx
+++ b/apps/account-portal/src/components/ui/button.tsx
@@ -1,30 +1,30 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva  } from "class-variance-authority"
-import type {VariantProps} from "class-variance-authority";
-
-import { cn } from "@/utils/utils"
+import type { VariantProps } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "@/utils/utils";
+import { Slot } from "@radix-ui/react-slot";
+import { cva } from "class-variance-authority";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "focus-visible:ring-ring inline-flex items-center justify-center gap-2 rounded-lg border border-transparent px-4 text-sm font-semibold tracking-[0.08em] whitespace-nowrap uppercase transition-[background-color,border-color,color,box-shadow,transform] focus-visible:ring-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+          "bg-primary text-primary-foreground border-[color:var(--realm-border-etched)] shadow-[0_12px_24px_color-mix(in_oklab,var(--realm-accent-brass)_24%,transparent)] hover:-translate-y-0.5 hover:bg-[color:var(--realm-accent-ember)]",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-xs",
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "bg-card/80 text-foreground hover:bg-accent/70 hover:text-primary border-[color:var(--realm-border-etched)] shadow-[inset_0_1px_0_color-mix(in_oklab,white_8%,transparent),0_10px_24px_color-mix(in_oklab,black_24%,transparent)] hover:border-[color:var(--realm-accent-brass)]",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary/80 text-secondary-foreground hover:bg-secondary border-[color:var(--realm-border-etched)] shadow-xs",
+        ghost:
+          "text-foreground hover:bg-accent/60 hover:text-primary border-transparent bg-transparent hover:border-[color:var(--realm-border-etched)]",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
         sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
+        lg: "h-11 rounded-lg px-8",
         icon: "h-9 w-9",
       },
     },
@@ -32,27 +32,28 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Button.displayName = "Button"
+    );
+  },
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/apps/account-portal/src/components/ui/button.tsx
+++ b/apps/account-portal/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 
 const buttonVariants = cva(
-  "focus-visible:ring-ring inline-flex items-center justify-center gap-2 rounded-lg border border-transparent px-4 text-sm font-semibold tracking-[0.08em] whitespace-nowrap uppercase transition-[background-color,border-color,color,box-shadow,transform] focus-visible:ring-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "focus-visible:ring-ring inline-flex items-center justify-center gap-2 rounded-lg border border-transparent px-4 text-sm font-semibold [letter-spacing:var(--tracking-ui)] whitespace-nowrap uppercase transition-[background-color,border-color,color,box-shadow,transform] focus-visible:ring-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/apps/account-portal/src/components/ui/card.tsx
+++ b/apps/account-portal/src/components/ui/card.tsx
@@ -32,14 +32,7 @@ const CardTitle = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "font-display text-primary leading-none font-semibold tracking-[0.14em] uppercase",
-      className,
-    )}
-    {...props}
-  />
+  <div ref={ref} className={cn("realm-card-title", className)} {...props} />
 ));
 CardTitle.displayName = "CardTitle";
 

--- a/apps/account-portal/src/components/ui/card.tsx
+++ b/apps/account-portal/src/components/ui/card.tsx
@@ -1,6 +1,5 @@
-import * as React from "react"
-
-import { cn } from "@/utils/utils"
+import * as React from "react";
+import { cn } from "@/utils/utils";
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -9,13 +8,13 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow-sm transition-shadow hover:shadow-md",
-      className
+      "realm-panel bg-card/85 text-card-foreground rounded-xl border shadow-lg backdrop-blur-sm transition-[border-color,box-shadow,transform] hover:-translate-y-0.5 hover:border-[color:var(--realm-accent-brass)] hover:shadow-xl",
+      className,
     )}
     {...props}
   />
-))
-Card.displayName = "Card"
+));
+Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
@@ -26,8 +25,8 @@ const CardHeader = React.forwardRef<
     className={cn("flex flex-col space-y-1.5 p-6", className)}
     {...props}
   />
-))
-CardHeader.displayName = "CardHeader"
+));
+CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
   HTMLDivElement,
@@ -35,11 +34,14 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("font-serif font-semibold leading-none tracking-tight", className)}
+    className={cn(
+      "font-display text-primary leading-none font-semibold tracking-[0.14em] uppercase",
+      className,
+    )}
     {...props}
   />
-))
-CardTitle.displayName = "CardTitle"
+));
+CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<
   HTMLDivElement,
@@ -47,19 +49,19 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-muted-foreground text-sm", className)}
     {...props}
   />
-))
-CardDescription.displayName = "CardDescription"
+));
+CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+));
+CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
@@ -70,7 +72,14 @@ const CardFooter = React.forwardRef<
     className={cn("flex items-center p-6 pt-0", className)}
     {...props}
   />
-))
-CardFooter.displayName = "CardFooter"
+));
+CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/apps/account-portal/src/components/ui/markdown-renderer.tsx
+++ b/apps/account-portal/src/components/ui/markdown-renderer.tsx
@@ -23,37 +23,22 @@ export function MarkdownRenderer({
       rehypePlugins={[rehypeRaw, rehypeSanitize]}
       urlTransform={(url) => {
         if (url.startsWith("ipfs://")) {
-          return url.replace(
-            "ipfs://",
-            env.VITE_PUBLIC_IPFS_GATEWAY ?? "",
-          );
+          return url.replace("ipfs://", env.VITE_PUBLIC_IPFS_GATEWAY ?? "");
         }
         return url;
       }}
       components={{
         h1: ({ _node, ...props }) => (
-          <h1
-            className="font-serif mb-4 mt-6 scroll-m-20 text-3xl font-extrabold tracking-tight lg:text-3xl"
-            {...props}
-          />
+          <h1 className="realm-prose-h1" {...props} />
         ),
         h2: ({ _node, ...props }) => (
-          <h2
-            className="font-serif mb-4 mt-6 scroll-m-20 border-b pb-2 text-2xl font-semibold tracking-tight first:mt-0"
-            {...props}
-          />
+          <h2 className="realm-prose-h2 first:mt-0" {...props} />
         ),
         h3: ({ _node, ...props }) => (
-          <h3
-            className="font-serif mb-4 mt-6 scroll-m-20 text-xl font-semibold tracking-tight"
-            {...props}
-          />
+          <h3 className="realm-prose-h3" {...props} />
         ),
         h4: ({ _node, ...props }) => (
-          <h4
-            className="font-serif mb-4 mt-6 scroll-m-20 text-lg font-semibold tracking-tight"
-            {...props}
-          />
+          <h4 className="realm-prose-h4" {...props} />
         ),
         p: ({ _node, ...props }) => (
           <p className="mb-4 leading-7 [&:not(:first-child)]:mt-6" {...props} />
@@ -136,7 +121,7 @@ export function MarkdownRenderer({
             );
           }
           return (
-            <pre className="mb-4 mt-6 overflow-x-auto rounded-lg border bg-black p-4">
+            <pre className="mt-6 mb-4 overflow-x-auto rounded-lg border bg-black p-4">
               <code
                 className="relative font-mono text-sm text-white"
                 {...props}

--- a/apps/account-portal/src/components/ui/metric-card.tsx
+++ b/apps/account-portal/src/components/ui/metric-card.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/utils/utils";
+
+interface MetricCardProps {
+  label: ReactNode;
+  value: ReactNode;
+  hint?: ReactNode;
+  className?: string;
+  valueClassName?: string;
+}
+
+export function MetricCard({
+  label,
+  value,
+  hint,
+  className,
+  valueClassName,
+}: MetricCardProps) {
+  return (
+    <Card className={cn("h-full", className)}>
+      <CardContent className="space-y-1 p-4">
+        <p className="text-muted-foreground text-sm">{label}</p>
+        <div className={cn("realm-stat text-2xl font-bold", valueClassName)}>
+          {value}
+        </div>
+        {hint ? <p className="text-muted-foreground text-sm">{hint}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/account-portal/src/components/ui/sidebar.tsx
+++ b/apps/account-portal/src/components/ui/sidebar.tsx
@@ -445,7 +445,7 @@ const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        "text-sidebar-foreground/72 font-display ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-[0.7rem] tracking-[0.16em] uppercase outline-hidden transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground/72 font-display ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-[0.7rem] [letter-spacing:var(--tracking-eyebrow)] uppercase outline-hidden transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
@@ -518,7 +518,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground active:bg-sidebar-accent/80 active:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent/80 data-[active=true]:text-primary data-[state=open]:hover:bg-sidebar-accent/80 data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-xl border border-transparent p-2 text-left text-sm font-semibold tracking-[0.04em] outline-hidden transition-[width,height,padding,background-color,border-color,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:border-[color:var(--realm-border-etched)] data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground active:bg-sidebar-accent/80 active:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent/80 data-[active=true]:text-primary data-[state=open]:hover:bg-sidebar-accent/80 data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-xl border border-transparent p-2 text-left text-sm font-semibold [letter-spacing:var(--tracking-ui)] uppercase outline-hidden transition-[width,height,padding,background-color,border-color,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:border-[color:var(--realm-border-etched)] data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/apps/account-portal/src/components/ui/sidebar.tsx
+++ b/apps/account-portal/src/components/ui/sidebar.tsx
@@ -187,7 +187,7 @@ const Sidebar = React.forwardRef<
       return (
         <div
           className={cn(
-            "w-(--sidebar-width) bg-sidebar text-sidebar-foreground flex h-full flex-col",
+            "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
             className,
           )}
           ref={ref}
@@ -204,7 +204,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-(--sidebar-width) bg-sidebar text-sidebar-foreground p-0 [&>button]:hidden"
+            className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
@@ -230,7 +230,7 @@ const Sidebar = React.forwardRef<
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
-            "w-(--sidebar-width) relative h-svh bg-transparent transition-[width] duration-200 ease-linear",
+            "relative h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
@@ -240,7 +240,7 @@ const Sidebar = React.forwardRef<
         />
         <div
           className={cn(
-            "w-(--sidebar-width) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] duration-200 ease-linear md:flex",
+            "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -254,7 +254,7 @@ const Sidebar = React.forwardRef<
         >
           <div
             data-sidebar="sidebar"
-            className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+            className="bg-sidebar/90 group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col backdrop-blur-xl group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
           >
             {children}
           </div>
@@ -306,7 +306,7 @@ const SidebarRail = React.forwardRef<
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
@@ -328,8 +328,8 @@ const SidebarInset = React.forwardRef<
     <main
       ref={ref}
       className={cn(
-        "bg-background relative flex min-h-svh flex-1 flex-col",
-        "peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
+        "relative flex min-h-svh flex-1 flex-col bg-transparent",
+        "peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className,
       )}
       {...props}
@@ -445,7 +445,7 @@ const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        "text-sidebar-foreground/70 outline-hidden ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground/72 font-display ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-[0.7rem] tracking-[0.16em] uppercase outline-hidden transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
@@ -466,7 +466,7 @@ const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar="group-action"
       className={cn(
-        "text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "group-data-[collapsible=icon]:hidden",
@@ -518,18 +518,19 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground group-has-data-[sidebar=menu-action]/menu-item:pr-8 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground active:bg-sidebar-accent/80 active:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent/80 data-[active=true]:text-primary data-[state=open]:hover:bg-sidebar-accent/80 data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-xl border border-transparent p-2 text-left text-sm font-semibold tracking-[0.04em] outline-hidden transition-[width,height,padding,background-color,border-color,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:border-[color:var(--realm-border-etched)] data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        default:
+          "hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground hover:border-[color:var(--realm-border-etched)]",
         outline:
-          "bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background/70 hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--realm-border-etched)]",
       },
       size: {
         default: "h-8 text-sm",
         sm: "h-7 text-xs",
-        lg: "group-data-[collapsible=icon]:p-0! h-12 text-sm",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
       },
     },
     defaultVariants: {
@@ -612,7 +613,7 @@ const SidebarMenuAction = React.forwardRef<
       ref={ref}
       data-sidebar="menu-action"
       className={cn(
-        "text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "peer-data-[size=sm]/menu-button:top-1",
@@ -637,7 +638,7 @@ const SidebarMenuBadge = React.forwardRef<
     ref={ref}
     data-sidebar="menu-badge"
     className={cn(
-      "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums",
+      "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
       "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
       "peer-data-[size=sm]/menu-button:top-1",
       "peer-data-[size=default]/menu-button:top-1.5",
@@ -675,7 +676,7 @@ const SidebarMenuSkeleton = React.forwardRef<
         />
       )}
       <Skeleton
-        className="max-w-(--skeleton-width) h-4 flex-1"
+        className="h-4 max-w-(--skeleton-width) flex-1"
         data-sidebar="menu-skeleton-text"
         style={
           {
@@ -696,7 +697,7 @@ const SidebarMenuSub = React.forwardRef<
     ref={ref}
     data-sidebar="menu-sub"
     className={cn(
-      "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+      "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-[color:var(--realm-border-etched)] px-2.5 py-0.5",
       "group-data-[collapsible=icon]:hidden",
       className,
     )}
@@ -728,8 +729,8 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
-        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground active:bg-sidebar-accent/70 active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-lg border border-transparent px-2 outline-hidden hover:border-[color:var(--realm-border-etched)] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "data-[active=true]:bg-sidebar-accent/70 data-[active=true]:text-primary data-[active=true]:border-[color:var(--realm-border-etched)]",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",
         "group-data-[collapsible=icon]:hidden",

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -47,6 +47,12 @@ describe("account portal theme", () => {
     expect(styles).toContain("var(--realm-accent-brass)");
   });
 
+  it("maps semantic borders onto the realm gold palette", () => {
+    expect(styles).toContain("--border: oklch(0.52 0.04 75);");
+    expect(styles).toContain("--border: oklch(0.38 0.04 75);");
+    expect(styles).toContain("border-color: var(--border);");
+  });
+
   it("points marketplace CTAs at market.realms.world", () => {
     expect(homepageSource).toContain('href="https://market.realms.world');
     expect(homepageSource).not.toContain("empire.realms.world/trade/realms");

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -6,8 +6,13 @@ import { describe, expect, it } from "vitest";
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const stylesPath = resolve(currentDir, "../styles.css");
 const buttonPath = resolve(currentDir, "../components/ui/button.tsx");
+const homepagePath = resolve(
+  currentDir,
+  "../components/modules/homepage/homepage.tsx",
+);
 const styles = readFileSync(stylesPath, "utf8");
 const buttonSource = readFileSync(buttonPath, "utf8");
+const homepageSource = readFileSync(homepagePath, "utf8");
 
 describe("account portal theme", () => {
   it("uses the realms-world-site font stack", () => {
@@ -33,5 +38,17 @@ describe("account portal theme", () => {
     expect(buttonSource).toContain(
       "hover:border-[color:var(--realm-accent-brass)]",
     );
+  });
+
+  it("uses brass accents instead of white edge highlights", () => {
+    expect(styles).not.toContain("white 10%");
+    expect(styles).not.toContain("white 8%");
+    expect(styles).not.toContain("white 7%");
+    expect(styles).toContain("var(--realm-accent-brass)");
+  });
+
+  it("points marketplace CTAs at market.realms.world", () => {
+    expect(homepageSource).toContain('href="https://market.realms.world');
+    expect(homepageSource).not.toContain("empire.realms.world/trade/realms");
   });
 });

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -22,6 +22,12 @@ const claimsPath = resolve(
   currentDir,
   "../components/modules/realms/claims.tsx",
 );
+const delegateListPath = resolve(currentDir, "../routes/delegate.list.tsx");
+const comingSoonPath = resolve(currentDir, "../routes/coming-soon.index.tsx");
+const markdownRendererPath = resolve(
+  currentDir,
+  "../components/ui/markdown-renderer.tsx",
+);
 const styles = readFileSync(stylesPath, "utf8");
 const buttonSource = readFileSync(buttonPath, "utf8");
 const homepageSource = readFileSync(homepagePath, "utf8");
@@ -31,6 +37,9 @@ const delegateProfileSource = readFileSync(delegateProfilePath, "utf8");
 const proposalDetailSource = readFileSync(proposalDetailPath, "utf8");
 const velordsIndexSource = readFileSync(velordsIndexPath, "utf8");
 const claimsSource = readFileSync(claimsPath, "utf8");
+const delegateListSource = readFileSync(delegateListPath, "utf8");
+const comingSoonSource = readFileSync(comingSoonPath, "utf8");
+const markdownRendererSource = readFileSync(markdownRendererPath, "utf8");
 
 describe("account portal theme", () => {
   it("uses the realms-world-site font stack", () => {
@@ -98,7 +107,7 @@ describe("account portal theme", () => {
 
   it("uses the shared page title treatment on primary portal screens", () => {
     expect(indexRouteSource).toContain("realm-page-title");
-    expect(velordsIndexSource).toContain("realm-page-title");
+    expect(velordsIndexSource).toContain("PageHeader");
     expect(proposalListSource).toContain("realm-page-title");
     expect(proposalDetailSource).toContain("realm-page-title");
     expect(delegateProfileSource).toContain("realm-page-title");
@@ -108,5 +117,26 @@ describe("account portal theme", () => {
   it("defines a shared card title utility", () => {
     expect(styles).toContain(".realm-card-title");
     expect(styles).toContain("font-size: 1.125rem;");
+  });
+
+  it("tokenizes heading tracking values", () => {
+    expect(styles).toContain("--tracking-page");
+    expect(styles).toContain("--tracking-card");
+    expect(styles).toContain("--tracking-eyebrow");
+  });
+
+  it("uses shared page shell primitives on outlier pages", () => {
+    expect(comingSoonSource).not.toContain("bg-gradient-to-r");
+    expect(delegateListSource).not.toContain("bg-background top-0");
+  });
+
+  it("uses shared components for the veLords header and stat cards", () => {
+    expect(velordsIndexSource).toContain("PageHeader");
+    expect(velordsIndexSource).toContain("MetricCard");
+  });
+
+  it("uses shared prose heading classes in markdown", () => {
+    expect(markdownRendererSource).toContain("realm-prose-h1");
+    expect(markdownRendererSource).toContain("realm-prose-h2");
   });
 });

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const stylesPath = resolve(currentDir, "../styles.css");
+const buttonPath = resolve(currentDir, "../components/ui/button.tsx");
+const styles = readFileSync(stylesPath, "utf8");
+const buttonSource = readFileSync(buttonPath, "utf8");
+
+describe("account portal theme", () => {
+  it("uses the realms-world-site font stack", () => {
+    expect(styles).toContain("family=Cinzel");
+    expect(styles).toContain("family=MedievalSharp");
+    expect(styles).toContain("family=Rajdhani");
+    expect(styles).toContain("--font-sans: Rajdhani, sans-serif;");
+    expect(styles).toContain("--font-serif: MedievalSharp, serif;");
+    expect(styles).toContain("--font-display: Cinzel, serif;");
+  });
+
+  it("defines the realms-world-site atmosphere tokens", () => {
+    expect(styles).toContain("--realm-bg-void");
+    expect(styles).toContain("--realm-surface-iron");
+    expect(styles).toContain("--realm-accent-ember");
+    expect(styles).toContain("--realm-accent-brass");
+    expect(styles).toContain("--realm-border-etched");
+  });
+
+  it("gives outline buttons an etched panel treatment", () => {
+    expect(buttonSource).toContain("border-[color:var(--realm-border-etched)]");
+    expect(buttonSource).toContain("bg-card/80");
+    expect(buttonSource).toContain(
+      "hover:border-[color:var(--realm-accent-brass)]",
+    );
+  });
+});

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -139,4 +139,17 @@ describe("account portal theme", () => {
     expect(markdownRendererSource).toContain("realm-prose-h1");
     expect(markdownRendererSource).toContain("realm-prose-h2");
   });
+
+  it("uses one dark surface value across header, sidebar, and panels", () => {
+    expect(styles).toContain("--card: oklch(0.16 0.006 260);");
+    expect(styles).toContain("--popover: oklch(0.16 0.006 260);");
+    expect(styles).toContain("--sidebar: oklch(0.16 0.006 260);");
+  });
+
+  it("keeps gold limited to structural text roles", () => {
+    expect(styles).toContain(".realm-card-title");
+    expect(styles).toContain("color: var(--primary);");
+    expect(styles).toContain(".realm-prose-h1");
+    expect(styles).toContain("color: var(--foreground);");
+  });
 });

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -10,9 +10,11 @@ const homepagePath = resolve(
   currentDir,
   "../components/modules/homepage/homepage.tsx",
 );
+const indexRoutePath = resolve(currentDir, "../routes/index.tsx");
 const styles = readFileSync(stylesPath, "utf8");
 const buttonSource = readFileSync(buttonPath, "utf8");
 const homepageSource = readFileSync(homepagePath, "utf8");
+const indexRouteSource = readFileSync(indexRoutePath, "utf8");
 
 describe("account portal theme", () => {
   it("uses the realms-world-site font stack", () => {
@@ -56,5 +58,10 @@ describe("account portal theme", () => {
   it("points marketplace CTAs at market.realms.world", () => {
     expect(homepageSource).toContain('href="https://market.realms.world');
     expect(homepageSource).not.toContain("empire.realms.world/trade/realms");
+  });
+
+  it("keeps the dashboard title inline instead of inside a framed panel", () => {
+    expect(indexRouteSource).not.toContain("realm-panel mb-4 rounded-3xl");
+    expect(indexRouteSource).toContain('className="mb-3 flex flex-wrap');
   });
 });

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -11,10 +11,26 @@ const homepagePath = resolve(
   "../components/modules/homepage/homepage.tsx",
 );
 const indexRoutePath = resolve(currentDir, "../routes/index.tsx");
+const proposalListPath = resolve(currentDir, "../routes/proposal.list.tsx");
+const delegateProfilePath = resolve(
+  currentDir,
+  "../routes/delegate.profile.tsx",
+);
+const proposalDetailPath = resolve(currentDir, "../routes/proposal.$id.tsx");
+const velordsIndexPath = resolve(currentDir, "../routes/velords.index.tsx");
+const claimsPath = resolve(
+  currentDir,
+  "../components/modules/realms/claims.tsx",
+);
 const styles = readFileSync(stylesPath, "utf8");
 const buttonSource = readFileSync(buttonPath, "utf8");
 const homepageSource = readFileSync(homepagePath, "utf8");
 const indexRouteSource = readFileSync(indexRoutePath, "utf8");
+const proposalListSource = readFileSync(proposalListPath, "utf8");
+const delegateProfileSource = readFileSync(delegateProfilePath, "utf8");
+const proposalDetailSource = readFileSync(proposalDetailPath, "utf8");
+const velordsIndexSource = readFileSync(velordsIndexPath, "utf8");
+const claimsSource = readFileSync(claimsPath, "utf8");
 
 describe("account portal theme", () => {
   it("uses the realms-world-site font stack", () => {
@@ -78,5 +94,19 @@ describe("account portal theme", () => {
       'CardContent className="p-12 text-center"',
     );
     expect(homepageSource).toContain('className="space-y-6"');
+  });
+
+  it("uses the shared page title treatment on primary portal screens", () => {
+    expect(indexRouteSource).toContain("realm-page-title");
+    expect(velordsIndexSource).toContain("realm-page-title");
+    expect(proposalListSource).toContain("realm-page-title");
+    expect(proposalDetailSource).toContain("realm-page-title");
+    expect(delegateProfileSource).toContain("realm-page-title");
+    expect(claimsSource).toContain("realm-page-title");
+  });
+
+  it("defines a shared card title utility", () => {
+    expect(styles).toContain(".realm-card-title");
+    expect(styles).toContain("font-size: 1.125rem;");
   });
 });

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -22,6 +22,10 @@ const claimsPath = resolve(
   currentDir,
   "../components/modules/realms/claims.tsx",
 );
+const appSidebarPath = resolve(
+  currentDir,
+  "../components/layout/app-sidebar.tsx",
+);
 const delegateListPath = resolve(currentDir, "../routes/delegate.list.tsx");
 const comingSoonPath = resolve(currentDir, "../routes/coming-soon.index.tsx");
 const markdownRendererPath = resolve(
@@ -37,6 +41,7 @@ const delegateProfileSource = readFileSync(delegateProfilePath, "utf8");
 const proposalDetailSource = readFileSync(proposalDetailPath, "utf8");
 const velordsIndexSource = readFileSync(velordsIndexPath, "utf8");
 const claimsSource = readFileSync(claimsPath, "utf8");
+const appSidebarSource = readFileSync(appSidebarPath, "utf8");
 const delegateListSource = readFileSync(delegateListPath, "utf8");
 const comingSoonSource = readFileSync(comingSoonPath, "utf8");
 const markdownRendererSource = readFileSync(markdownRendererPath, "utf8");
@@ -151,5 +156,13 @@ describe("account portal theme", () => {
     expect(styles).toContain("color: var(--primary);");
     expect(styles).toContain(".realm-prose-h1");
     expect(styles).toContain("color: var(--foreground);");
+  });
+
+  it("uses the cleaned sidebar destination map", () => {
+    expect(appSidebarSource).not.toContain('title: "Claims"');
+    expect(appSidebarSource).toContain("https://market.realms.world");
+    expect(appSidebarSource).toContain('url: "https://realms.world"');
+    expect(appSidebarSource).toContain('url: "https://blitz.realms.world"');
+    expect(appSidebarSource).toContain('url: "https://docs.realms.world"');
   });
 });

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -55,6 +55,12 @@ describe("account portal theme", () => {
     expect(styles).toContain("border-color: var(--border);");
   });
 
+  it("uses flat backgrounds instead of gradients", () => {
+    expect(styles).not.toContain("radial-gradient(");
+    expect(styles).not.toContain("background-image:");
+    expect(styles).not.toContain("background: linear-gradient(");
+  });
+
   it("points marketplace CTAs at market.realms.world", () => {
     expect(homepageSource).toContain('href="https://market.realms.world');
     expect(homepageSource).not.toContain("empire.realms.world/trade/realms");
@@ -63,5 +69,14 @@ describe("account portal theme", () => {
   it("keeps the dashboard title inline instead of inside a framed panel", () => {
     expect(indexRouteSource).not.toContain("realm-panel mb-4 rounded-3xl");
     expect(indexRouteSource).toContain('className="mb-3 flex flex-wrap');
+  });
+
+  it("keeps homepage spacing tight and consistent", () => {
+    expect(homepageSource).not.toContain('className="space-y-8"');
+    expect(homepageSource).not.toContain('className="grid grid-cols-1 gap-8');
+    expect(homepageSource).not.toContain(
+      'CardContent className="p-12 text-center"',
+    );
+    expect(homepageSource).toContain('className="space-y-6"');
   });
 });

--- a/apps/account-portal/src/routes/coming-soon.index.tsx
+++ b/apps/account-portal/src/routes/coming-soon.index.tsx
@@ -1,4 +1,5 @@
-import { Card } from "@/components/ui/card";
+import { PageHeader } from "@/components/layout/page-header";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/coming-soon/")({
@@ -7,12 +8,17 @@ export const Route = createFileRoute("/coming-soon/")({
 
 function RouteComponent() {
   return (
-    <div className="to-background via-background-sidebar from-secondary flex h-screen items-center justify-center bg-gradient-to-r">
-      <Card className="rounded bg-card p-12 text-center shadow-lg">
-        <h1 className="font-display mb-4 text-5xl font-bold">Coming Soon</h1>
-        <p className="text-xl">
-          We're working hard to bring you an amazing new experience. Stay tuned!
-        </p>
+    <div className="realm-shell flex min-h-screen items-center justify-center px-6">
+      <Card className="w-full max-w-xl text-center">
+        <CardHeader>
+          <PageHeader
+            eyebrow="Portal"
+            title="Coming Soon"
+            description="We're working hard to bring you an amazing new experience. Stay tuned!"
+            className="mb-0 text-center md:flex-col md:items-center"
+          />
+        </CardHeader>
+        <CardContent />
       </Card>
     </div>
   );

--- a/apps/account-portal/src/routes/delegate.list.tsx
+++ b/apps/account-portal/src/routes/delegate.list.tsx
@@ -29,7 +29,7 @@ function RouteComponent() {
   return (
     <div className="h-screen overflow-auto">
       {/* Sticky search input */}
-      <div className="bg-background top-0 z-10 mb-4 flex justify-between gap-6 border-b p-3 sm:sticky">
+      <div className="bg-card/85 top-0 z-10 mb-4 flex justify-between gap-6 rounded-xl border p-3 backdrop-blur-sm sm:sticky">
         <Input
           type="text"
           className="h-12 w-full rounded border p-3"
@@ -48,7 +48,10 @@ function RouteComponent() {
           </div>
         }
       >
-        <DelegateList searchQuery={deferredSearchQuery} sortMethod={sortMethod} />
+        <DelegateList
+          searchQuery={deferredSearchQuery}
+          sortMethod={sortMethod}
+        />
       </Suspense>
     </div>
   );

--- a/apps/account-portal/src/routes/delegate.profile.tsx
+++ b/apps/account-portal/src/routes/delegate.profile.tsx
@@ -68,12 +68,13 @@ function RouteComponent() {
       }
     >
       <SidebarInset>
-        <div className="container mx-auto p-8">
-          <h1 className="mb-4 text-2xl font-semibold">
+        <div className="container mx-auto space-y-4 p-8">
+          <p className="realm-eyebrow">Governance</p>
+          <h1 className="realm-page-title text-3xl sm:text-4xl">
             Your Profile {shortenAddress(session?.user.id)}
           </h1>
           {!isLoading && (
-            <Card className="mb-8">
+            <Card>
               <CardContent className="p-6">
                 <DelegateProfileForm
                   delegate={

--- a/apps/account-portal/src/routes/delegate.profile.tsx
+++ b/apps/account-portal/src/routes/delegate.profile.tsx
@@ -68,7 +68,7 @@ function RouteComponent() {
       }
     >
       <SidebarInset>
-        <div className="container mx-auto space-y-4 p-8">
+        <div className="container mx-auto space-y-4 px-4 py-6 sm:px-6 sm:py-8">
           <p className="realm-eyebrow">Governance</p>
           <h1 className="realm-page-title text-3xl sm:text-4xl">
             Your Profile {shortenAddress(session?.user.id)}

--- a/apps/account-portal/src/routes/index.tsx
+++ b/apps/account-portal/src/routes/index.tsx
@@ -31,10 +31,10 @@ function IndexComponent() {
     return <LoginCard />;
   }
   return (
-    <div className="realm-shell flex flex-col gap-6 p-4 sm:px-8">
+    <div className="realm-shell flex flex-col gap-4 px-4 py-3 sm:px-6">
       {/* Dashboard Statistics */}
-      <div className="realm-panel mb-4 rounded-3xl p-5 sm:p-8">
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+      <div>
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
             <p className="realm-eyebrow">Account Portal</p>
             <h1 className="realm-page-title text-3xl sm:text-4xl">Dashboard</h1>

--- a/apps/account-portal/src/routes/index.tsx
+++ b/apps/account-portal/src/routes/index.tsx
@@ -31,11 +31,14 @@ function IndexComponent() {
     return <LoginCard />;
   }
   return (
-    <div className="flex flex-col gap-4 p-4 sm:px-8">
+    <div className="realm-shell flex flex-col gap-6 p-4 sm:px-8">
       {/* Dashboard Statistics */}
-      <div className="mb-4">
-        <div className="mb-2 flex items-center justify-between">
-          <h1 className="text-2xl font-bold">Dashboard</h1>
+      <div className="realm-panel mb-4 rounded-3xl p-5 sm:p-8">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+          <div className="space-y-1">
+            <p className="realm-eyebrow">Account Portal</p>
+            <h1 className="realm-page-title text-3xl sm:text-4xl">Dashboard</h1>
+          </div>
           <EthereumConnect />
         </div>
         <Suspense fallback={<HomepageSkeleton />}>

--- a/apps/account-portal/src/routes/index.tsx
+++ b/apps/account-portal/src/routes/index.tsx
@@ -31,7 +31,7 @@ function IndexComponent() {
     return <LoginCard />;
   }
   return (
-    <div className="realm-shell flex flex-col gap-4 px-4 py-3 sm:px-6">
+    <div className="realm-shell flex flex-col gap-4 px-4 py-6 sm:px-6 sm:py-8">
       {/* Dashboard Statistics */}
       <div>
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">

--- a/apps/account-portal/src/routes/proposal.$id.tsx
+++ b/apps/account-portal/src/routes/proposal.$id.tsx
@@ -16,8 +16,8 @@ import { useCurrentDelegate } from "@/hooks/governance/use-current-delegate";
 import { useVotingPower } from "@/hooks/governance/use-voting-power";
 import { useStarkDisplayName } from "@/hooks/use-stark-name";
 import { getProposalQueryOptions } from "@/lib/snapshot/getProposals";
-import { isMatchingProposalVote } from "@/lib/snapshot/proposal-id";
 import { getUserVotesQueryOptions } from "@/lib/snapshot/getUserVotes";
+import { isMatchingProposalVote } from "@/lib/snapshot/proposal-id";
 import {
   formatAddress,
   shortenAddress,
@@ -76,8 +76,8 @@ function RouteComponent() {
   );
 
   // Find the vote that matches this proposal ID
-  const userVoteRef = userVotesQuery?.votes?.find(
-    (vote) => isMatchingProposalVote(vote?.proposal, id),
+  const userVoteRef = userVotesQuery?.votes?.find((vote) =>
+    isMatchingProposalVote(vote?.proposal, id),
   );
 
   const proposal = proposalQuery.proposal;
@@ -143,8 +143,11 @@ function RouteComponent() {
           <Card className="mb-8">
             <CardHeader>
               <div className="flex flex-col gap-2">
+                <p className="realm-eyebrow">Governance</p>
                 <div className="flex items-center justify-between gap-3">
-                  <h1 className="text-3xl font-bold">{title}</h1>
+                  <h1 className="realm-page-title text-3xl sm:text-4xl">
+                    {title}
+                  </h1>
                   {proposalStatus && (
                     <Badge
                       variant={"outline"}
@@ -190,7 +193,7 @@ function RouteComponent() {
           {votingPower && (
             <Badge
               variant={"outline"}
-              className="max-w-30 mx-auto flex justify-center rounded text-center text-lg"
+              className="mx-auto flex max-w-30 justify-center rounded text-center text-lg"
             >
               {Number(votingPower).toString()} Realms
             </Badge>

--- a/apps/account-portal/src/routes/proposal.list.tsx
+++ b/apps/account-portal/src/routes/proposal.list.tsx
@@ -58,7 +58,7 @@ function RouteComponent() {
       }}
     >
       <SidebarInset>
-        <div className="container space-y-3 p-4 sm:p-8">
+        <div className="container space-y-3 px-4 py-6 sm:px-6 sm:py-8">
           <p className="realm-eyebrow">Governance</p>
           <h1 className="realm-page-title text-3xl sm:text-4xl">Proposals</h1>
           <Suspense fallback={<ProposalListSkeleton />}>

--- a/apps/account-portal/src/routes/proposal.list.tsx
+++ b/apps/account-portal/src/routes/proposal.list.tsx
@@ -39,7 +39,9 @@ export const Route = createFileRoute("/proposal/list")({
 function RouteComponent() {
   const { data } = useCurrentDelegate();
   const delegateAddress =
-    data && BigInt(data) !== 0n ? formatAddress(num.toHex(BigInt(data))) : undefined;
+    data && BigInt(data) !== 0n
+      ? formatAddress(num.toHex(BigInt(data)))
+      : undefined;
 
   const currentDelegateQuery = useQuery(
     getDelegateByIDQueryOptions({
@@ -56,8 +58,9 @@ function RouteComponent() {
       }}
     >
       <SidebarInset>
-        <div className="container p-4 sm:p-8">
-          <h1 className="text-2xl font-semibold">Proposals</h1>
+        <div className="container space-y-3 p-4 sm:p-8">
+          <p className="realm-eyebrow">Governance</p>
+          <h1 className="realm-page-title text-3xl sm:text-4xl">Proposals</h1>
           <Suspense fallback={<ProposalListSkeleton />}>
             <ProposalList limit={20} delegateId={currentDelegate?.user} />
           </Suspense>

--- a/apps/account-portal/src/routes/realms.bridge.tsx
+++ b/apps/account-portal/src/routes/realms.bridge.tsx
@@ -2,6 +2,7 @@ import type { RowSelectionState } from "@tanstack/react-table";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import EthereumIcon from "@/components/icons/ethereum.svg?react";
 import StarknetIcon from "@/components/icons/starknet.svg?react";
+import { PageHeader } from "@/components/layout/page-header";
 import BridgeSidebar from "@/components/modules/realms/bridge-sidebar";
 import { BridgeTable, columns } from "@/components/modules/realms/bridge-table";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -117,41 +118,39 @@ function RouteComponent() {
       className="flex flex-1"
     >
       <SidebarInset className="px-6">
-        <div className="my-8 flex items-center justify-center space-x-4">
-          <Button
-            size="lg"
-            className={`bg-primary/80 hover:bg-primary/80 cursor-default rounded-full`}
-          >
-            From:
+        <PageHeader eyebrow="Realms" title="Starknet Bridge" className="mt-6" />
+        <div className="mb-6 flex items-center justify-center gap-3">
+          <div className="realm-subtle-panel flex items-center gap-2 rounded-lg px-4 py-2.5">
+            <span className="text-muted-foreground text-sm">From</span>
             {selectedAsset === "Ethereum" ? (
               <>
-                <EthereumIcon className="w-6! h-6!" />
-                Ethereum
+                <EthereumIcon className="h-5 w-5" />
+                <span className="font-semibold">Ethereum</span>
               </>
             ) : (
               <>
-                <StarknetIcon className="w-6! h-6!" />
-                Starknet
+                <StarknetIcon className="h-5 w-5" />
+                <span className="font-semibold">Starknet</span>
               </>
             )}
+          </div>
+          <Button size="icon" variant="outline" onClick={swapAssets} className="rounded-full">
+            <ArrowLeftRight className="h-4 w-4" />
           </Button>
-          <Button size="icon" onClick={swapAssets} className="rounded">
-            <ArrowLeftRight className="h-7 w-7" />
-          </Button>
-          <Button size="lg" className="rounded-full" onClick={swapAssets}>
-            To:
+          <div className="realm-subtle-panel flex items-center gap-2 rounded-lg px-4 py-2.5">
+            <span className="text-muted-foreground text-sm">To</span>
             {selectedAsset === "Ethereum" ? (
               <>
-                <StarknetIcon className="w-6! h-6!" />
-                Starknet
+                <StarknetIcon className="h-5 w-5" />
+                <span className="font-semibold">Starknet</span>
               </>
             ) : (
               <>
-                <EthereumIcon className="w-6! h-6!" />
-                Ethereum
+                <EthereumIcon className="h-5 w-5" />
+                <span className="font-semibold">Ethereum</span>
               </>
             )}
-          </Button>
+          </div>
         </div>
         {selectedAsset === "Ethereum" && !l1Address && (
           <Alert className="mb-4 rounded border-warning">
@@ -160,14 +159,7 @@ function RouteComponent() {
               Your Ethereum wallet is not connected
             </AlertTitle>
             <AlertDescription>
-              <Button
-                className="pl-0 pr-2"
-                variant={"link"}
-                // onClick={openConnectModal}
-              >
-                Connect
-              </Button>
-              to view and bridge your Realms
+              Connect your Ethereum wallet using the sidebar to view and bridge your Realms
             </AlertDescription>
           </Alert>
         )}
@@ -179,13 +171,13 @@ function RouteComponent() {
             </AlertTitle>
             <AlertDescription>
               <Button
-                className="pl-0 pr-2"
-                variant={"link"}
+                className="h-auto p-0"
+                variant="link"
                 onClick={() => openStarknetKitModal()}
               >
-                Connect
+                Connect your Starknet wallet
               </Button>
-              to view and bridge your Realms
+              {" "}to view and bridge your Realms
             </AlertDescription>
           </Alert>
         )}

--- a/apps/account-portal/src/routes/realms.index.tsx
+++ b/apps/account-portal/src/routes/realms.index.tsx
@@ -71,12 +71,12 @@ function RealmsComponent() {
     <div className="flex flex-col gap-2 p-4">
       <div className="flex gap-2">
         <Link to={`/realms/bridge`}>
-          <Button variant={"outline"} size="lg" className="rounded px-3">
-            <BridgeIcon className="!h-5 !w-5" /> Starknet Bridge
+          <Button variant="outline" size="sm">
+            <BridgeIcon className="h-5! w-5!" /> Starknet Bridge
           </Button>
         </Link>
         <Link to={`/realms/claims`}>
-          <Button variant={"outline"} size="lg" className="rounded px-3">
+          <Button variant="outline" size="sm">
             <HandCoins /> Claim Lords
           </Button>
         </Link>

--- a/apps/account-portal/src/routes/velords.index.tsx
+++ b/apps/account-portal/src/routes/velords.index.tsx
@@ -1,7 +1,9 @@
 import { lazy, Suspense, useMemo } from "react";
+import { PageHeader } from "@/components/layout/page-header";
 import { VelordsLockActivity } from "@/components/modules/velords/lock-activity";
 import { VelordsSourceBreakdown } from "@/components/modules/velords/source-breakdown";
 import { Button } from "@/components/ui/button";
+import { MetricCard } from "@/components/ui/metric-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
 import { useVelordsData } from "@/hooks/use-velords-data";
@@ -222,81 +224,59 @@ function RouteComponent() {
   };
 
   return (
-    <div className="bg-background min-h-screen">
+    <div className="min-h-screen">
       <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-10">
-        <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <div className="space-y-2">
-            <p className="realm-eyebrow">Lords</p>
-            <h1 className="realm-page-title text-3xl sm:text-4xl">
-              veLords Dashboard
-            </h1>
-            <p className="text-muted-foreground text-base sm:text-lg">
-              Stake $LORDS in the Lordship Protocol and monitor reward
-              performance.
-            </p>
-          </div>
-          <div className="flex gap-2">
-            <Button variant="outline" onClick={handleCopyLink}>
-              <Link2 className="mr-2 h-4 w-4" />
-              Copy Link
-            </Button>
-            <Button variant="outline" onClick={handleCopySummary}>
-              <Copy className="mr-2 h-4 w-4" />
-              Copy Summary
-            </Button>
-          </div>
-        </div>
+        <PageHeader
+          eyebrow="Lords"
+          title="veLords Dashboard"
+          description="Stake $LORDS in the Lordship Protocol and monitor reward performance."
+          actions={
+            <>
+              <Button variant="outline" onClick={handleCopyLink}>
+                <Link2 className="mr-2 h-4 w-4" />
+                Copy Link
+              </Button>
+              <Button variant="outline" onClick={handleCopySummary}>
+                <Copy className="mr-2 h-4 w-4" />
+                Copy Summary
+              </Button>
+            </>
+          }
+        />
 
         <div className="mb-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-          <div className="bg-card rounded-lg border p-4">
-            <div className="text-muted-foreground text-sm">
-              Total Voting Power (veLORDS)
-            </div>
-            <div className="text-2xl font-bold">
-              {totalSupply ?? "Loading..."}
-            </div>
-            {userBalance !== undefined && userSharePercent !== undefined && (
-              <div className="text-muted-foreground mt-1 text-sm">
-                Your share: {userBalance} ({userSharePercent}%)
-              </div>
-            )}
-          </div>
-          <div className="bg-card rounded-lg border p-4">
-            <div className="text-muted-foreground text-sm">LORDS Locked</div>
-            <div className="text-2xl font-bold">
-              {lordsLocked ?? "Loading..."}
-            </div>
-          </div>
-          <div className="bg-card rounded-lg border p-4">
-            <div className="text-muted-foreground text-sm">TVL</div>
-            <div className="text-2xl font-bold">
-              {typeof tvl === "number" && Number.isFinite(tvl)
+          <MetricCard
+            label="Total Voting Power (veLORDS)"
+            value={totalSupply ?? "Loading..."}
+            hint={
+              userBalance !== undefined && userSharePercent !== undefined
+                ? `Your share: ${userBalance} (${userSharePercent}%)`
+                : undefined
+            }
+          />
+          <MetricCard
+            label="LORDS Locked"
+            value={lordsLocked ?? "Loading..."}
+          />
+          <MetricCard
+            label="TVL"
+            value={
+              typeof tvl === "number" && Number.isFinite(tvl)
                 ? `$${tvl.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
                 : isTVLLoading
                   ? "Loading..."
-                  : "$0"}
-            </div>
-          </div>
-          <div className="bg-card rounded-lg border p-4">
-            <div className="text-muted-foreground text-sm">Rewards (7d)</div>
-            <div className="text-2xl font-bold">
-              {rewards7d ?? "Loading..."}
-            </div>
-          </div>
-          <div className="bg-card rounded-lg border p-4">
-            <div className="text-muted-foreground text-sm">Rewards (30d)</div>
-            <div className="text-2xl font-bold">
-              {rewards30d ?? "Loading..."}
-            </div>
-          </div>
-          <div className="bg-card rounded-lg border p-4">
-            <div className="text-muted-foreground text-sm">
-              Trailing APY (4w avg)
-            </div>
-            <div className="text-2xl font-bold">
-              {formatNumber(trailingApy, 2)}%
-            </div>
-          </div>
+                  : "$0"
+            }
+          />
+          <MetricCard label="Rewards (7d)" value={rewards7d ?? "Loading..."} />
+          <MetricCard
+            label="Rewards (30d)"
+            value={rewards30d ?? "Loading..."}
+          />
+          <MetricCard
+            label="Trailing APY (4w avg)"
+            value={`${formatNumber(trailingApy, 2)}%`}
+          />
         </div>
 
         <div className="grid gap-6 lg:gap-8 xl:grid-cols-5">

--- a/apps/account-portal/src/routes/velords.index.tsx
+++ b/apps/account-portal/src/routes/velords.index.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { VelordsLockActivity } from "@/components/modules/velords/lock-activity";
 import { VelordsSourceBreakdown } from "@/components/modules/velords/source-breakdown";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MetricCard } from "@/components/ui/metric-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
@@ -225,7 +226,7 @@ function RouteComponent() {
 
   return (
     <div className="min-h-screen">
-      <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-10">
+      <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8">
         <PageHeader
           eyebrow="Lords"
           title="veLords Dashboard"
@@ -281,26 +282,28 @@ function RouteComponent() {
 
         <div className="grid gap-6 lg:gap-8 xl:grid-cols-5">
           <div className="space-y-6 xl:col-span-3">
-            <div className="bg-card rounded-lg border p-6">
-              <Suspense
-                fallback={
-                  <div className="h-[360px] w-full animate-pulse rounded-md border" />
-                }
-              >
-                <VeLordsRewardsChart
-                  selectedPeriod={selectedPeriod}
-                  totalSupplyRaw={totalSupplyRaw}
-                  data={veLordsBurnsQuery.data ?? []}
-                  onTimePeriodChange={handleTimePeriodChange}
-                  isLoading={veLordsBurnsQuery.isLoading}
-                  errorMessage={
-                    veLordsBurnsQuery.error instanceof Error
-                      ? veLordsBurnsQuery.error.message
-                      : undefined
+            <Card>
+              <CardContent className="p-6">
+                <Suspense
+                  fallback={
+                    <div className="h-[360px] w-full animate-pulse rounded-md border" />
                   }
-                />
-              </Suspense>
-            </div>
+                >
+                  <VeLordsRewardsChart
+                    selectedPeriod={selectedPeriod}
+                    totalSupplyRaw={totalSupplyRaw}
+                    data={veLordsBurnsQuery.data ?? []}
+                    onTimePeriodChange={handleTimePeriodChange}
+                    isLoading={veLordsBurnsQuery.isLoading}
+                    errorMessage={
+                      veLordsBurnsQuery.error instanceof Error
+                        ? veLordsBurnsQuery.error.message
+                        : undefined
+                    }
+                  />
+                </Suspense>
+              </CardContent>
+            </Card>
 
             <Tabs value={selectedView} onValueChange={handleViewChange}>
               <TabsList>
@@ -351,33 +354,37 @@ function RouteComponent() {
           </div>
 
           <div className="space-y-6 xl:col-span-2">
-            <div className="bg-card rounded-lg border p-4">
-              <div className="text-sm font-medium">Your Position</div>
-              <div className="text-muted-foreground mt-2 space-y-1 text-sm">
-                <div>veLORDS Balance: {userBalance ?? "-"}</div>
-                <div>
-                  Supply Share:{" "}
-                  {userSharePercent ? `${userSharePercent}%` : "-"}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle>Your Position</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-muted-foreground space-y-1 text-sm">
+                  <div>veLORDS Balance: {userBalance ?? "-"}</div>
+                  <div>
+                    Supply Share:{" "}
+                    {userSharePercent ? `${userSharePercent}%` : "-"}
+                  </div>
+                  <div>Locked LORDS: {userLocked?.amount ?? "-"}</div>
+                  <div>
+                    Unlock Time:{" "}
+                    {userLocked?.unlockTime
+                      ? new Date(
+                          userLocked.unlockTime * 1000,
+                        ).toLocaleDateString()
+                      : "-"}
+                  </div>
+                  <div>
+                    Est. Weekly Rewards:{" "}
+                    {estimatedWeeklyRewards !== undefined
+                      ? `~${formatNumber(estimatedWeeklyRewards, 2)} LORDS`
+                      : "-"}
+                  </div>
                 </div>
-                <div>Locked LORDS: {userLocked?.amount ?? "-"}</div>
-                <div>
-                  Unlock Time:{" "}
-                  {userLocked?.unlockTime
-                    ? new Date(
-                        userLocked.unlockTime * 1000,
-                      ).toLocaleDateString()
-                    : "-"}
-                </div>
-                <div>
-                  Est. Weekly Rewards:{" "}
-                  {estimatedWeeklyRewards !== undefined
-                    ? `~${formatNumber(estimatedWeeklyRewards, 2)} LORDS`
-                    : "-"}
-                </div>
-              </div>
-            </div>
+              </CardContent>
+            </Card>
 
-            <div className="bg-card rounded-lg border">
+            <Card>
               <Suspense
                 fallback={
                   <div className="h-[320px] w-full animate-pulse rounded-md border" />
@@ -385,9 +392,9 @@ function RouteComponent() {
               >
                 <StakeLords />
               </Suspense>
-            </div>
+            </Card>
             {address && (
-              <div className="bg-card rounded-lg border">
+              <Card>
                 <Suspense
                   fallback={
                     <div className="h-[220px] w-full animate-pulse rounded-md border" />
@@ -395,7 +402,7 @@ function RouteComponent() {
                 >
                   <VelordsRewards />
                 </Suspense>
-              </div>
+              </Card>
             )}
           </div>
         </div>

--- a/apps/account-portal/src/routes/velords.index.tsx
+++ b/apps/account-portal/src/routes/velords.index.tsx
@@ -1,19 +1,8 @@
 import { lazy, Suspense, useMemo } from "react";
-import { Button } from "@/components/ui/button";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
-import { useAccount } from "@starknet-start/react";
-import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-import { Copy, Link2 } from "lucide-react";
-import { formatUnits } from "viem";
-
 import { VelordsLockActivity } from "@/components/modules/velords/lock-activity";
 import { VelordsSourceBreakdown } from "@/components/modules/velords/source-breakdown";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
 import { useVelordsData } from "@/hooks/use-velords-data";
 import {
@@ -25,6 +14,11 @@ import { getVelordsBurnsQueryOptions } from "@/lib/getVeLordsBurns";
 import { calculateTrailingApyPercent } from "@/lib/velords-analytics";
 import { seo } from "@/utils/seo";
 import { formatNumber } from "@/utils/utils";
+import { useAccount } from "@starknet-start/react";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { Copy, Link2 } from "lucide-react";
+import { formatUnits } from "viem";
 
 type VelordsPeriod = "3m" | "6m" | "1y";
 type VelordsView = "overview" | "sources" | "locks" | "trends";
@@ -161,7 +155,9 @@ function RouteComponent() {
   const estimatedWeeklyRewards = useMemo(() => {
     const latestWeek = rewardsSeriesQuery.data?.weekly.at(-1);
     if (!latestWeek || !userSharePercent) return undefined;
-    const latestWeekRewards = Number(formatUnits(BigInt(latestWeek.totalWei), 18));
+    const latestWeekRewards = Number(
+      formatUnits(BigInt(latestWeek.totalWei), 18),
+    );
     return (latestWeekRewards * Number(userSharePercent)) / 100;
   }, [rewardsSeriesQuery.data?.weekly, userSharePercent]);
 
@@ -230,11 +226,13 @@ function RouteComponent() {
       <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-10">
         <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div className="space-y-2">
-            <h1 className="font-display text-3xl font-bold tracking-tight sm:text-4xl">
+            <p className="realm-eyebrow">Lords</p>
+            <h1 className="realm-page-title text-3xl sm:text-4xl">
               veLords Dashboard
             </h1>
             <p className="text-muted-foreground text-base sm:text-lg">
-              Stake $LORDS in the Lordship Protocol and monitor reward performance.
+              Stake $LORDS in the Lordship Protocol and monitor reward
+              performance.
             </p>
           </div>
           <div className="flex gap-2">
@@ -251,8 +249,12 @@ function RouteComponent() {
 
         <div className="mb-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           <div className="bg-card rounded-lg border p-4">
-            <div className="text-sm text-muted-foreground">Total Voting Power (veLORDS)</div>
-            <div className="text-2xl font-bold">{totalSupply ?? "Loading..."}</div>
+            <div className="text-muted-foreground text-sm">
+              Total Voting Power (veLORDS)
+            </div>
+            <div className="text-2xl font-bold">
+              {totalSupply ?? "Loading..."}
+            </div>
             {userBalance !== undefined && userSharePercent !== undefined && (
               <div className="text-muted-foreground mt-1 text-sm">
                 Your share: {userBalance} ({userSharePercent}%)
@@ -260,11 +262,13 @@ function RouteComponent() {
             )}
           </div>
           <div className="bg-card rounded-lg border p-4">
-            <div className="text-sm text-muted-foreground">LORDS Locked</div>
-            <div className="text-2xl font-bold">{lordsLocked ?? "Loading..."}</div>
+            <div className="text-muted-foreground text-sm">LORDS Locked</div>
+            <div className="text-2xl font-bold">
+              {lordsLocked ?? "Loading..."}
+            </div>
           </div>
           <div className="bg-card rounded-lg border p-4">
-            <div className="text-sm text-muted-foreground">TVL</div>
+            <div className="text-muted-foreground text-sm">TVL</div>
             <div className="text-2xl font-bold">
               {typeof tvl === "number" && Number.isFinite(tvl)
                 ? `$${tvl.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
@@ -274,23 +278,35 @@ function RouteComponent() {
             </div>
           </div>
           <div className="bg-card rounded-lg border p-4">
-            <div className="text-sm text-muted-foreground">Rewards (7d)</div>
-            <div className="text-2xl font-bold">{rewards7d ?? "Loading..."}</div>
+            <div className="text-muted-foreground text-sm">Rewards (7d)</div>
+            <div className="text-2xl font-bold">
+              {rewards7d ?? "Loading..."}
+            </div>
           </div>
           <div className="bg-card rounded-lg border p-4">
-            <div className="text-sm text-muted-foreground">Rewards (30d)</div>
-            <div className="text-2xl font-bold">{rewards30d ?? "Loading..."}</div>
+            <div className="text-muted-foreground text-sm">Rewards (30d)</div>
+            <div className="text-2xl font-bold">
+              {rewards30d ?? "Loading..."}
+            </div>
           </div>
           <div className="bg-card rounded-lg border p-4">
-            <div className="text-sm text-muted-foreground">Trailing APY (4w avg)</div>
-            <div className="text-2xl font-bold">{formatNumber(trailingApy, 2)}%</div>
+            <div className="text-muted-foreground text-sm">
+              Trailing APY (4w avg)
+            </div>
+            <div className="text-2xl font-bold">
+              {formatNumber(trailingApy, 2)}%
+            </div>
           </div>
         </div>
 
         <div className="grid gap-6 lg:gap-8 xl:grid-cols-5">
           <div className="space-y-6 xl:col-span-3">
             <div className="bg-card rounded-lg border p-6">
-              <Suspense fallback={<div className="h-[360px] w-full animate-pulse rounded-md border" />}>
+              <Suspense
+                fallback={
+                  <div className="h-[360px] w-full animate-pulse rounded-md border" />
+                }
+              >
                 <VeLordsRewardsChart
                   selectedPeriod={selectedPeriod}
                   totalSupplyRaw={totalSupplyRaw}
@@ -359,12 +375,17 @@ function RouteComponent() {
               <div className="text-sm font-medium">Your Position</div>
               <div className="text-muted-foreground mt-2 space-y-1 text-sm">
                 <div>veLORDS Balance: {userBalance ?? "-"}</div>
-                <div>Supply Share: {userSharePercent ? `${userSharePercent}%` : "-"}</div>
+                <div>
+                  Supply Share:{" "}
+                  {userSharePercent ? `${userSharePercent}%` : "-"}
+                </div>
                 <div>Locked LORDS: {userLocked?.amount ?? "-"}</div>
                 <div>
                   Unlock Time:{" "}
                   {userLocked?.unlockTime
-                    ? new Date(userLocked.unlockTime * 1000).toLocaleDateString()
+                    ? new Date(
+                        userLocked.unlockTime * 1000,
+                      ).toLocaleDateString()
                     : "-"}
                 </div>
                 <div>

--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -171,9 +171,9 @@
   .dark {
     --background: oklch(0.18 0 0);
     --foreground: oklch(0.95 0 0);
-    --card: oklch(0.21 0 0);
+    --card: oklch(0.16 0.006 260);
     --card-foreground: oklch(0.95 0 0);
-    --popover: oklch(0.21 0 0);
+    --popover: oklch(0.16 0.006 260);
     --popover-foreground: oklch(0.95 0 0);
     --primary: oklch(0.92 0.05 66.17);
     --primary-foreground: oklch(0.2 0.02 200.2);
@@ -197,7 +197,7 @@
     --chart-3: oklch(0.29 0 0);
     --chart-4: oklch(0.35 0.02 67);
     --chart-5: oklch(0.92 0.05 67.09);
-    --sidebar: oklch(0.21 0.01 285.89);
+    --sidebar: oklch(0.16 0.006 260);
     --sidebar-foreground: oklch(0.97 0 286.38);
     --sidebar-primary: oklch(0.92 0.05 66.17);
     --sidebar-primary-foreground: oklch(0.12 0.012 260);
@@ -311,7 +311,7 @@
   }
 
   .realm-card-title {
-    color: var(--primary);
+    color: var(--foreground);
     font-family: var(--font-display);
     font-size: 1.125rem;
     font-weight: 600;
@@ -331,7 +331,7 @@
   .realm-prose-h1 {
     margin: 1.5rem 0 1rem;
     scroll-margin-top: 5rem;
-    color: var(--primary);
+    color: var(--foreground);
     font-family: var(--font-display);
     font-size: 1.875rem;
     font-weight: 700;

--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -1,8 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Doto:wght@100..900&family=Bebas+Neue&family=Inconsolata:wght@200..900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400..900&family=MedievalSharp&family=Rajdhani:wght@400;500;600;700&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap");
 
-@import 'tailwindcss';
+@import "tailwindcss";
 
-@plugin 'tailwindcss-animate';
+@plugin "tailwindcss-animate";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -74,6 +74,7 @@
       height: var(--radix-accordion-content-height);
     }
   }
+
   @keyframes accordion-up {
     from {
       height: var(--radix-accordion-content-height);
@@ -84,14 +85,6 @@
   }
 }
 
-/*
-  The default border color has changed to `currentColor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
-*/
 @layer base {
   *,
   ::after,
@@ -103,127 +96,270 @@
 }
 
 @layer base {
-  @layer base {
-    :root {
-      --background: oklch(0.9582 0.0152 90.2357);
-      --foreground: oklch(0.3760 0.0225 64.3434);
-      --card: oklch(0.9914 0.0098 87.4695);
-      --card-foreground: oklch(0.3760 0.0225 64.3434);
-      --popover: oklch(0.9914 0.0098 87.4695);
-      --popover-foreground: oklch(0.3760 0.0225 64.3434);
-      --primary: oklch(0.6180 0.0778 65.5444);
-      --primary-foreground: oklch(1.0000 0 0);
-      --secondary: oklch(0.8846 0.0302 85.5655);
-      --secondary-foreground: oklch(0.4313 0.0300 64.9288);
-      --muted: oklch(0.9239 0.0190 83.0636);
-      --muted-foreground: oklch(0.5391 0.0387 71.1655);
-      --accent: oklch(0.8348 0.0426 88.8064);
-      --accent-foreground: oklch(0.3760 0.0225 64.3434);
-      --destructive: oklch(0.5471 0.1438 32.9149);
-      --destructive-foreground: oklch(1.0000 0 0);
-      --border: oklch(0.8606 0.0321 84.5881);
-      --input: oklch(0.8606 0.0321 84.5881);
-      --ring: oklch(0.6180 0.0778 65.5444);
-      --success: oklch(0.59 0.15 142);
-      --success-foreground: oklch(1.0 0 0);
-      --warning: oklch(0.75 0.12 85);
-      --warning-foreground: oklch(0.35 0.06 60);
-      --chart-1: oklch(0.6180 0.0778 65.5444);
-      --chart-2: oklch(0.5604 0.0624 68.5805);
-      --chart-3: oklch(0.4851 0.0570 72.6827);
-      --chart-4: oklch(0.6777 0.0624 64.7755);
-      --chart-5: oklch(0.7264 0.0581 66.6967);
-      --sidebar: oklch(0.9239 0.0190 83.0636);
-      --sidebar-foreground: oklch(0.3760 0.0225 64.3434);
-      --sidebar-primary: oklch(0.6180 0.0778 65.5444);
-      --sidebar-primary-foreground: oklch(1.0000 0 0);
-      --sidebar-accent: oklch(0.8348 0.0426 88.8064);
-      --sidebar-accent-foreground: oklch(0.3760 0.0225 64.3434);
-      --sidebar-border: oklch(0.8606 0.0321 84.5881);
-      --sidebar-ring: oklch(0.6180 0.0778 65.5444);
-      --font-sans: Inconsolata, monospace;
-      --font-serif: Bebas Neue, sans-serif;
-      --font-mono: Inconsolata, monospace;
-      --font-display: Doto, monospace;
-      --radius: 0.5rem;
-      --shadow-2xs: 2px 3px 5px 0px hsl(28 13% 20% / 0.06);
-      --shadow-xs: 2px 3px 5px 0px hsl(28 13% 20% / 0.06);
-      --shadow-sm: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 1px 2px -1px hsl(28 13% 20% / 0.12);
-      --shadow: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 1px 2px -1px hsl(28 13% 20% / 0.12);
-      --shadow-md: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 2px 4px -1px hsl(28 13% 20% / 0.12);
-      --shadow-lg: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 4px 6px -1px hsl(28 13% 20% / 0.12);
-      --shadow-xl: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 8px 10px -1px hsl(28 13% 20% / 0.12);
-      --shadow-2xl: 2px 3px 5px 0px hsl(28 13% 20% / 0.30);
-    }
-    .dark {
-      --background: oklch(0.2747 0.0139 57.6523);
-      --foreground: oklch(0.9239 0.0190 83.0636);
-      --card: oklch(0.3237 0.0155 59.0603);
-      --card-foreground: oklch(0.9239 0.0190 83.0636);
-      --popover: oklch(0.3237 0.0155 59.0603);
-      --popover-foreground: oklch(0.9239 0.0190 83.0636);
-      --primary: oklch(0.7264 0.0581 66.6967);
-      --primary-foreground: oklch(0.2747 0.0139 57.6523);
-      --secondary: oklch(0.3795 0.0181 57.1280);
-      --secondary-foreground: oklch(0.9239 0.0190 83.0636);
-      --muted: oklch(0.3237 0.0155 59.0603);
-      --muted-foreground: oklch(0.7982 0.0243 82.1078);
-      --accent: oklch(0.4186 0.0281 56.3404);
-      --accent-foreground: oklch(0.9239 0.0190 83.0636);
-      --destructive: oklch(0.5471 0.1438 32.9149);
-      --destructive-foreground: oklch(1.0000 0 0);
-      --border: oklch(0.3795 0.0181 57.1280);
-      --input: oklch(0.3795 0.0181 57.1280);
-      --ring: oklch(0.7264 0.0581 66.6967);
-      --success: oklch(0.55 0.15 145);
-      --success-foreground: oklch(0.95 0.02 140);
-      --warning: oklch(0.65 0.12 85);
-      --warning-foreground: oklch(0.95 0.02 80);
-      --chart-1: oklch(0.7264 0.0581 66.6967);
-      --chart-2: oklch(0.6777 0.0624 64.7755);
-      --chart-3: oklch(0.6180 0.0778 65.5444);
-      --chart-4: oklch(0.5604 0.0624 68.5805);
-      --chart-5: oklch(0.4851 0.0570 72.6827);
-      --sidebar: oklch(0.2747 0.0139 57.6523);
-      --sidebar-foreground: oklch(0.9239 0.0190 83.0636);
-      --sidebar-primary: oklch(0.7264 0.0581 66.6967);
-      --sidebar-primary-foreground: oklch(0.2747 0.0139 57.6523);
-      --sidebar-accent: oklch(0.4186 0.0281 56.3404);
-      --sidebar-accent-foreground: oklch(0.9239 0.0190 83.0636);
-      --sidebar-border: oklch(0.3795 0.0181 57.1280);
-      --sidebar-ring: oklch(0.7264 0.0581 66.6967);
-      --font-sans: Inconsolata, monospace;
-      --font-serif: Bebas Neue, sans-serif;
-      --font-mono: Inconsolata, monospace;
-      --font-display: Doto, monospace;
-      --radius: 0.5rem;
-      --shadow-2xs: 2px 3px 5px 0px hsl(28 13% 20% / 0.06);
-      --shadow-xs: 2px 3px 5px 0px hsl(28 13% 20% / 0.06);
-      --shadow-sm: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 1px 2px -1px hsl(28 13% 20% / 0.12);
-      --shadow: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 1px 2px -1px hsl(28 13% 20% / 0.12);
-      --shadow-md: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 2px 4px -1px hsl(28 13% 20% / 0.12);
-      --shadow-lg: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 4px 6px -1px hsl(28 13% 20% / 0.12);
-      --shadow-xl: 2px 3px 5px 0px hsl(28 13% 20% / 0.12), 2px 8px 10px -1px hsl(28 13% 20% / 0.12);
-      --shadow-2xl: 2px 3px 5px 0px hsl(28 13% 20% / 0.30);
-    }
+  :root {
+    --background: oklch(0.98 0 0);
+    --foreground: oklch(0.24 0 0);
+    --card: oklch(0.99 0 0);
+    --card-foreground: oklch(0.24 0 0);
+    --popover: oklch(0.99 0 0);
+    --popover-foreground: oklch(0.24 0 0);
+    --primary: oklch(0.43 0.04 41.99);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(0.92 0.07 74.37);
+    --secondary-foreground: oklch(0.35 0.07 40.83);
+    --muted: oklch(0.95 0 0);
+    --muted-foreground: oklch(0.5 0 0);
+    --accent: oklch(0.93 0 0);
+    --accent-foreground: oklch(0.24 0 0);
+    --destructive: oklch(0.63 0.19 33.34);
+    --destructive-foreground: oklch(1 0 0);
+    --border: oklch(0.88 0 0);
+    --input: oklch(0.88 0 0);
+    --ring: oklch(0.43 0.04 41.99);
+    --success: oklch(0.56 0.15 145);
+    --success-foreground: oklch(0.98 0.02 140);
+    --warning: oklch(0.72 0.12 85);
+    --warning-foreground: oklch(0.28 0.05 55);
+    --chart-1: oklch(0.43 0.04 41.99);
+    --chart-2: oklch(0.92 0.07 74.37);
+    --chart-3: oklch(0.93 0 0);
+    --chart-4: oklch(0.94 0.05 75.5);
+    --chart-5: oklch(0.43 0.04 41.67);
+    --sidebar: oklch(0.99 0 0);
+    --sidebar-foreground: oklch(0.26 0 0);
+    --sidebar-primary: oklch(0.43 0.04 41.99);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.98 0 0);
+    --sidebar-accent-foreground: oklch(0.33 0 0);
+    --sidebar-border: oklch(0.94 0 0);
+    --sidebar-ring: oklch(0.77 0 0);
+    --realm-bg-void: oklch(0.22 0.012 260);
+    --realm-bg-smoke: oklch(0.3 0.018 245);
+    --realm-surface-iron: oklch(0.3 0.01 80);
+    --realm-surface-slate: oklch(0.35 0.012 260);
+    --realm-accent-ember: oklch(0.66 0.12 55);
+    --realm-accent-brass: oklch(0.72 0.1 85);
+    --realm-accent-arcane: oklch(0.62 0.08 260);
+    --realm-border-etched: oklch(0.52 0.04 75);
+    --realm-border-strong: oklch(0.44 0.03 80);
+    --realm-glow-soft: color-mix(in oklab, var(--primary) 30%, transparent);
+    --realm-vignette: linear-gradient(
+      180deg,
+      transparent 0%,
+      color-mix(in oklab, black 38%, transparent) 100%
+    );
+    --font-sans: Rajdhani, sans-serif;
+    --font-serif: MedievalSharp, serif;
+    --font-mono: Source Code Pro, monospace;
+    --font-display: Cinzel, serif;
+    --radius: 0.75rem;
+    --shadow-2xs: 0 1px 3px 0 hsl(0 0% 0% / 0.05);
+    --shadow-xs: 0 1px 3px 0 hsl(0 0% 0% / 0.05);
+    --shadow-sm:
+      0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+    --shadow: 0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+    --shadow-md:
+      0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+    --shadow-lg:
+      0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+    --shadow-xl:
+      0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
+    --shadow-2xl: 0 1px 3px 0 hsl(0 0% 0% / 0.25);
   }
-}
-@layer base {
-  * {
-    @apply border-border;
+
+  .dark {
+    --background: oklch(0.18 0 0);
+    --foreground: oklch(0.95 0 0);
+    --card: oklch(0.21 0 0);
+    --card-foreground: oklch(0.95 0 0);
+    --popover: oklch(0.21 0 0);
+    --popover-foreground: oklch(0.95 0 0);
+    --primary: oklch(0.92 0.05 66.17);
+    --primary-foreground: oklch(0.2 0.02 200.2);
+    --secondary: oklch(0.32 0.02 63.7);
+    --secondary-foreground: oklch(0.92 0.05 66.17);
+    --muted: oklch(0.25 0 0);
+    --muted-foreground: oklch(0.77 0 0);
+    --accent: oklch(0.29 0 0);
+    --accent-foreground: oklch(0.95 0 0);
+    --destructive: oklch(0.63 0.19 33.34);
+    --destructive-foreground: oklch(1 0 0);
+    --border: oklch(0.24 0.01 91.75);
+    --input: oklch(0.4 0 0);
+    --ring: oklch(0.92 0.05 66.17);
+    --success: oklch(0.55 0.15 145);
+    --success-foreground: oklch(0.95 0.02 140);
+    --warning: oklch(0.65 0.12 85);
+    --warning-foreground: oklch(0.95 0.02 80);
+    --chart-1: oklch(0.92 0.05 66.17);
+    --chart-2: oklch(0.32 0.02 63.7);
+    --chart-3: oklch(0.29 0 0);
+    --chart-4: oklch(0.35 0.02 67);
+    --chart-5: oklch(0.92 0.05 67.09);
+    --sidebar: oklch(0.21 0.01 285.89);
+    --sidebar-foreground: oklch(0.97 0 286.38);
+    --sidebar-primary: oklch(0.92 0.05 66.17);
+    --sidebar-primary-foreground: oklch(0.12 0.012 260);
+    --sidebar-accent: oklch(0.27 0.01 286.03);
+    --sidebar-accent-foreground: oklch(0.97 0 286.38);
+    --sidebar-border: oklch(0.27 0.01 286.03);
+    --sidebar-ring: oklch(0.87 0.01 286.29);
+    --realm-bg-void: oklch(0.12 0.012 260);
+    --realm-bg-smoke: oklch(0.17 0.016 250);
+    --realm-surface-iron: oklch(0.23 0.01 80);
+    --realm-surface-slate: oklch(0.27 0.012 260);
+    --realm-accent-ember: oklch(0.72 0.14 55);
+    --realm-accent-brass: oklch(0.78 0.1 85);
+    --realm-accent-arcane: oklch(0.65 0.08 260);
+    --realm-border-etched: oklch(0.38 0.04 75);
+    --realm-border-strong: oklch(0.46 0.04 82);
+    --realm-glow-soft: color-mix(in oklab, var(--primary) 32%, transparent);
+    --realm-vignette: linear-gradient(
+      180deg,
+      transparent 0%,
+      color-mix(in oklab, black 55%, transparent) 100%
+    );
+    --font-sans: Rajdhani, sans-serif;
+    --font-serif: MedievalSharp, serif;
+    --font-mono: Source Code Pro, monospace;
+    --font-display: Cinzel, serif;
+    --radius: 0.75rem;
+    --shadow-2xs: 0 1px 3px 0 hsl(0 0% 0% / 0.05);
+    --shadow-xs: 0 1px 3px 0 hsl(0 0% 0% / 0.05);
+    --shadow-sm:
+      0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+    --shadow: 0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+    --shadow-md:
+      0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+    --shadow-lg:
+      0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+    --shadow-xl:
+      0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
+    --shadow-2xl: 0 1px 3px 0 hsl(0 0% 0% / 0.25);
   }
+
+  html {
+    background: var(--realm-bg-void);
+  }
+
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-sans);
+    background-image:
+      radial-gradient(
+        circle at top left,
+        color-mix(in oklab, var(--realm-accent-arcane) 35%, transparent),
+        transparent 32%
+      ),
+      radial-gradient(
+        circle at top right,
+        color-mix(in oklab, var(--realm-accent-ember) 20%, transparent),
+        transparent 28%
+      ),
+      linear-gradient(
+        180deg,
+        color-mix(in oklab, var(--realm-bg-smoke) 88%, black 12%) 0%,
+        var(--background) 100%
+      );
+    background-attachment: fixed;
   }
-  h1, h2, h3 {
-    font-family: var(--font-serif);
-  }
-}
 
-@layer base {
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background:
+      linear-gradient(
+        135deg,
+        color-mix(in oklab, var(--realm-border-etched) 12%, transparent),
+        transparent 35%
+      ),
+      var(--realm-vignette);
+    opacity: 0.75;
+    z-index: 0;
+  }
+
+  body > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: var(--font-display);
+    letter-spacing: 0.08em;
+  }
+
   button:not(:disabled),
   [role="button"]:not(:disabled) {
     cursor: pointer;
+  }
+
+  ::selection {
+    background: color-mix(in oklab, var(--realm-accent-brass) 55%, transparent);
+    color: var(--foreground);
+  }
+}
+
+@layer components {
+  .realm-shell {
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--card) 88%, transparent) 0%,
+      color-mix(in oklab, var(--background) 72%, transparent) 100%
+    );
+  }
+
+  .realm-panel {
+    border: 1px solid var(--realm-border-etched);
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, white 3%, var(--card)) 0%,
+      color-mix(in oklab, var(--realm-surface-slate) 28%, var(--card)) 100%
+    );
+    box-shadow:
+      inset 0 1px 0 color-mix(in oklab, white 10%, transparent),
+      0 16px 40px color-mix(in oklab, black 45%, transparent);
+  }
+
+  .realm-subtle-panel {
+    border: 1px solid
+      color-mix(in oklab, var(--realm-border-etched) 72%, transparent);
+    background: color-mix(in oklab, var(--accent) 55%, transparent);
+    box-shadow: inset 0 1px 0 color-mix(in oklab, white 7%, transparent);
+  }
+
+  .realm-page-title {
+    font-family: var(--font-display);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  .realm-eyebrow {
+    color: color-mix(in oklab, var(--primary) 82%, white 18%);
+    font-family: var(--font-serif);
+    font-size: 0.8rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+
+  .realm-stat {
+    font-family: var(--font-display);
+    letter-spacing: 0.06em;
+  }
+
+  .realm-interactive-row {
+    border: 1px solid
+      color-mix(in oklab, var(--realm-border-etched) 76%, transparent);
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--card) 90%, transparent) 0%,
+      color-mix(in oklab, var(--accent) 55%, transparent) 100%
+    );
+    box-shadow: inset 0 1px 0 color-mix(in oklab, white 8%, transparent);
   }
 }
 

--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -91,7 +91,7 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-gray-200, currentColor);
+    border-color: var(--border);
   }
 }
 
@@ -113,8 +113,8 @@
     --accent-foreground: oklch(0.24 0 0);
     --destructive: oklch(0.63 0.19 33.34);
     --destructive-foreground: oklch(1 0 0);
-    --border: oklch(0.88 0 0);
-    --input: oklch(0.88 0 0);
+    --border: oklch(0.52 0.04 75);
+    --input: oklch(0.44 0.03 80);
     --ring: oklch(0.43 0.04 41.99);
     --success: oklch(0.56 0.15 145);
     --success-foreground: oklch(0.98 0.02 140);
@@ -131,7 +131,7 @@
     --sidebar-primary-foreground: oklch(0.99 0 0);
     --sidebar-accent: oklch(0.98 0 0);
     --sidebar-accent-foreground: oklch(0.33 0 0);
-    --sidebar-border: oklch(0.94 0 0);
+    --sidebar-border: oklch(0.52 0.04 75);
     --sidebar-ring: oklch(0.77 0 0);
     --realm-bg-void: oklch(0.22 0.012 260);
     --realm-bg-smoke: oklch(0.3 0.018 245);
@@ -184,8 +184,8 @@
     --accent-foreground: oklch(0.95 0 0);
     --destructive: oklch(0.63 0.19 33.34);
     --destructive-foreground: oklch(1 0 0);
-    --border: oklch(0.24 0.01 91.75);
-    --input: oklch(0.4 0 0);
+    --border: oklch(0.38 0.04 75);
+    --input: oklch(0.46 0.04 82);
     --ring: oklch(0.92 0.05 66.17);
     --success: oklch(0.55 0.15 145);
     --success-foreground: oklch(0.95 0.02 140);
@@ -202,7 +202,7 @@
     --sidebar-primary-foreground: oklch(0.12 0.012 260);
     --sidebar-accent: oklch(0.27 0.01 286.03);
     --sidebar-accent-foreground: oklch(0.97 0 286.38);
-    --sidebar-border: oklch(0.27 0.01 286.03);
+    --sidebar-border: oklch(0.38 0.04 75);
     --sidebar-ring: oklch(0.87 0.01 286.29);
     --realm-bg-void: oklch(0.12 0.012 260);
     --realm-bg-smoke: oklch(0.17 0.016 250);

--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -317,11 +317,12 @@
     border: 1px solid var(--realm-border-etched);
     background: linear-gradient(
       180deg,
-      color-mix(in oklab, white 3%, var(--card)) 0%,
+      color-mix(in oklab, var(--realm-accent-brass) 6%, var(--card)) 0%,
       color-mix(in oklab, var(--realm-surface-slate) 28%, var(--card)) 100%
     );
     box-shadow:
-      inset 0 1px 0 color-mix(in oklab, white 10%, transparent),
+      inset 0 1px 0
+        color-mix(in oklab, var(--realm-accent-brass) 24%, transparent),
       0 16px 40px color-mix(in oklab, black 45%, transparent);
   }
 
@@ -329,7 +330,8 @@
     border: 1px solid
       color-mix(in oklab, var(--realm-border-etched) 72%, transparent);
     background: color-mix(in oklab, var(--accent) 55%, transparent);
-    box-shadow: inset 0 1px 0 color-mix(in oklab, white 7%, transparent);
+    box-shadow: inset 0 1px 0
+      color-mix(in oklab, var(--realm-accent-brass) 18%, transparent);
   }
 
   .realm-page-title {
@@ -359,7 +361,8 @@
       color-mix(in oklab, var(--card) 90%, transparent) 0%,
       color-mix(in oklab, var(--accent) 55%, transparent) 100%
     );
-    box-shadow: inset 0 1px 0 color-mix(in oklab, white 8%, transparent);
+    box-shadow: inset 0 1px 0
+      color-mix(in oklab, var(--realm-accent-brass) 18%, transparent);
   }
 }
 

--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -148,6 +148,11 @@
     --font-serif: MedievalSharp, serif;
     --font-mono: Source Code Pro, monospace;
     --font-display: Cinzel, serif;
+    --tracking-base: 0.08em;
+    --tracking-page: 0.16em;
+    --tracking-card: 0.14em;
+    --tracking-eyebrow: 0.18em;
+    --tracking-ui: 0.08em;
     --radius: 0.75rem;
     --shadow-2xs: 0 1px 3px 0 hsl(0 0% 0% / 0.05);
     --shadow-xs: 0 1px 3px 0 hsl(0 0% 0% / 0.05);
@@ -215,6 +220,11 @@
     --font-serif: MedievalSharp, serif;
     --font-mono: Source Code Pro, monospace;
     --font-display: Cinzel, serif;
+    --tracking-base: 0.08em;
+    --tracking-page: 0.16em;
+    --tracking-card: 0.14em;
+    --tracking-eyebrow: 0.18em;
+    --tracking-ui: 0.08em;
     --radius: 0.75rem;
     --shadow-2xs: 0 1px 3px 0 hsl(0 0% 0% / 0.05);
     --shadow-xs: 0 1px 3px 0 hsl(0 0% 0% / 0.05);
@@ -254,7 +264,7 @@
   h3,
   h4 {
     font-family: var(--font-display);
-    letter-spacing: 0.08em;
+    letter-spacing: var(--tracking-base);
   }
 
   button:not(:disabled),
@@ -296,7 +306,7 @@
 
   .realm-page-title {
     font-family: var(--font-display);
-    letter-spacing: 0.16em;
+    letter-spacing: var(--tracking-page);
     text-transform: uppercase;
   }
 
@@ -305,7 +315,7 @@
     font-family: var(--font-display);
     font-size: 1.125rem;
     font-weight: 600;
-    letter-spacing: 0.14em;
+    letter-spacing: var(--tracking-card);
     line-height: 1.1;
     text-transform: uppercase;
   }
@@ -314,7 +324,53 @@
     color: color-mix(in oklab, var(--primary) 82%, white 18%);
     font-family: var(--font-serif);
     font-size: 0.8rem;
-    letter-spacing: 0.18em;
+    letter-spacing: var(--tracking-eyebrow);
+    text-transform: uppercase;
+  }
+
+  .realm-prose-h1 {
+    margin: 1.5rem 0 1rem;
+    scroll-margin-top: 5rem;
+    color: var(--primary);
+    font-family: var(--font-display);
+    font-size: 1.875rem;
+    font-weight: 700;
+    letter-spacing: var(--tracking-card);
+    text-transform: uppercase;
+  }
+
+  .realm-prose-h2 {
+    margin: 1.5rem 0 1rem;
+    scroll-margin-top: 5rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.5rem;
+    color: var(--primary);
+    font-family: var(--font-display);
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: var(--tracking-card);
+    text-transform: uppercase;
+  }
+
+  .realm-prose-h3 {
+    margin: 1.5rem 0 1rem;
+    scroll-margin-top: 5rem;
+    color: var(--foreground);
+    font-family: var(--font-display);
+    font-size: 1.25rem;
+    font-weight: 600;
+    letter-spacing: var(--tracking-base);
+    text-transform: uppercase;
+  }
+
+  .realm-prose-h4 {
+    margin: 1.5rem 0 1rem;
+    scroll-margin-top: 5rem;
+    color: var(--foreground);
+    font-family: var(--font-display);
+    font-size: 1.125rem;
+    font-weight: 600;
+    letter-spacing: var(--tracking-base);
     text-transform: uppercase;
   }
 

--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -143,11 +143,7 @@
     --realm-border-etched: oklch(0.52 0.04 75);
     --realm-border-strong: oklch(0.44 0.03 80);
     --realm-glow-soft: color-mix(in oklab, var(--primary) 30%, transparent);
-    --realm-vignette: linear-gradient(
-      180deg,
-      transparent 0%,
-      color-mix(in oklab, black 38%, transparent) 100%
-    );
+    --realm-vignette: none;
     --font-sans: Rajdhani, sans-serif;
     --font-serif: MedievalSharp, serif;
     --font-mono: Source Code Pro, monospace;
@@ -214,11 +210,7 @@
     --realm-border-etched: oklch(0.38 0.04 75);
     --realm-border-strong: oklch(0.46 0.04 82);
     --realm-glow-soft: color-mix(in oklab, var(--primary) 32%, transparent);
-    --realm-vignette: linear-gradient(
-      180deg,
-      transparent 0%,
-      color-mix(in oklab, black 55%, transparent) 100%
-    );
+    --realm-vignette: none;
     --font-sans: Rajdhani, sans-serif;
     --font-serif: MedievalSharp, serif;
     --font-mono: Source Code Pro, monospace;
@@ -245,39 +237,11 @@
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-sans);
-    background-image:
-      radial-gradient(
-        circle at top left,
-        color-mix(in oklab, var(--realm-accent-arcane) 35%, transparent),
-        transparent 32%
-      ),
-      radial-gradient(
-        circle at top right,
-        color-mix(in oklab, var(--realm-accent-ember) 20%, transparent),
-        transparent 28%
-      ),
-      linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--realm-bg-smoke) 88%, black 12%) 0%,
-        var(--background) 100%
-      );
-    background-attachment: fixed;
+    background: var(--background);
   }
 
   body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    background:
-      linear-gradient(
-        135deg,
-        color-mix(in oklab, var(--realm-border-etched) 12%, transparent),
-        transparent 35%
-      ),
-      var(--realm-vignette);
-    opacity: 0.75;
-    z-index: 0;
+    content: none;
   }
 
   body > * {
@@ -306,19 +270,15 @@
 
 @layer components {
   .realm-shell {
-    background: linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--card) 88%, transparent) 0%,
-      color-mix(in oklab, var(--background) 72%, transparent) 100%
-    );
+    background: transparent;
   }
 
   .realm-panel {
     border: 1px solid var(--realm-border-etched);
-    background: linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--realm-accent-brass) 6%, var(--card)) 0%,
-      color-mix(in oklab, var(--realm-surface-slate) 28%, var(--card)) 100%
+    background: color-mix(
+      in oklab,
+      var(--card) 92%,
+      var(--realm-surface-slate)
     );
     box-shadow:
       inset 0 1px 0
@@ -329,7 +289,7 @@
   .realm-subtle-panel {
     border: 1px solid
       color-mix(in oklab, var(--realm-border-etched) 72%, transparent);
-    background: color-mix(in oklab, var(--accent) 55%, transparent);
+    background: color-mix(in oklab, var(--accent) 72%, transparent);
     box-shadow: inset 0 1px 0
       color-mix(in oklab, var(--realm-accent-brass) 18%, transparent);
   }
@@ -356,11 +316,7 @@
   .realm-interactive-row {
     border: 1px solid
       color-mix(in oklab, var(--realm-border-etched) 76%, transparent);
-    background: linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--card) 90%, transparent) 0%,
-      color-mix(in oklab, var(--accent) 55%, transparent) 100%
-    );
+    background: color-mix(in oklab, var(--card) 88%, var(--accent));
     box-shadow: inset 0 1px 0
       color-mix(in oklab, var(--realm-accent-brass) 18%, transparent);
   }

--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -300,6 +300,16 @@
     text-transform: uppercase;
   }
 
+  .realm-card-title {
+    color: var(--primary);
+    font-family: var(--font-display);
+    font-size: 1.125rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    line-height: 1.1;
+    text-transform: uppercase;
+  }
+
   .realm-eyebrow {
     color: color-mix(in oklab, var(--primary) 82%, white 18%);
     font-family: var(--font-serif);


### PR DESCRIPTION
## Summary
- swap the account portal onto the realms-world-site font stack and semantic color palette
- restyle shared shell primitives and dashboard panels while keeping the existing account page structure
- add a small theme regression test covering the imported fonts, atmosphere tokens, and etched outline button treatment

## Verification
- ./packages/apibara/node_modules/.bin/vitest run apps/account-portal/src/lib/theme.test.ts --environment node
- pnpm --filter @realms-world/account-portal lint src/components/ui/button.tsx src/components/ui/card.tsx src/components/ui/sidebar.tsx src/components/layout/header.tsx src/routes/index.tsx src/components/layout/login-card.tsx src/components/modules/homepage/homepage.tsx src/lib/theme.test.ts
- npx -p node@20.19.0 -c 'cd apps/account-portal && ./node_modules/.bin/dotenv -e ../../.env -- ./node_modules/.bin/vite build'

## Notes
- the workspace default Node is 20.9.0, so the app build was verified under a temporary Node 20.19.0 runtime because Vite 7 requires 20.19+.