### PR TITLE
Clean up portal styles and remove dead code

### DIFF
--- a/apps/account-portal/src/components/layout/header.tsx
+++ b/apps/account-portal/src/components/layout/header.tsx
@@ -72,7 +72,7 @@ export function Header() {
             />
           </Link>
         </div>
-        <div className="flex flex-1 items-center justify-between px-1.5 sm:px-4">
+        <div className="flex flex-1 items-center justify-between px-3 sm:px-4">
           <div className="flex items-center justify-between gap-2">
             <SidebarTrigger className="-ml-1" />
             <ModeToggle />

--- a/apps/account-portal/src/components/layout/login-card.tsx
+++ b/apps/account-portal/src/components/layout/login-card.tsx
@@ -8,6 +8,26 @@ import {
 
 import { StarknetWalletButton } from "./starknet-wallet-button";
 
+function FeatureItem({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-baseline gap-2 px-1">
+      <span className="text-primary text-xs">&#x25C6;</span>
+      <div>
+        <h3 className="realm-card-title text-sm">
+          {title}
+        </h3>
+        <p className="text-muted-foreground text-xs">{description}</p>
+      </div>
+    </div>
+  );
+}
+
 export function LoginCard() {
   return (
     <Card className="mx-auto mt-12 w-full max-w-md">
@@ -41,25 +61,5 @@ export function LoginCard() {
         <StarknetWalletButton className="w-full" variant="reference" />
       </CardContent>
     </Card>
-  );
-}
-
-function FeatureItem({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="flex items-baseline gap-2 px-1">
-      <span className="text-primary text-xs">&#x25C6;</span>
-      <div>
-        <h3 className="font-display text-sm font-semibold tracking-[var(--tracking-card)] uppercase">
-          {title}
-        </h3>
-        <p className="text-muted-foreground text-xs">{description}</p>
-      </div>
-    </div>
   );
 }

--- a/apps/account-portal/src/components/modules/governance/delegate-card.tsx
+++ b/apps/account-portal/src/components/modules/governance/delegate-card.tsx
@@ -56,27 +56,6 @@ export function DelegateCard({
     });
   };
 
-  // Utility function to return the proper React icon for each platform
-  const getSocialIcon = (platform: string) => {
-    switch (platform.toLowerCase()) {
-      /*case "twitter":
-        return <FaTwitter className="text-blue-500" />;
-      case "linkedin":
-        return <FaLinkedin className="text-blue-700" />;
-      case "github":
-        return <FaGithub className="text-gray-800" />;*/
-      default:
-        return null;
-    }
-  };
-
-  const socialMedia = {
-    twitter: delegate.delegateProfile?.twitter,
-    github: delegate.delegateProfile?.github,
-    telegram: delegate.delegateProfile?.telegram,
-    discord: delegate.delegateProfile?.discord,
-  };
-
   const name = useStarkDisplayName(delegate.user as `0x${string}`);
 
   return (
@@ -152,19 +131,6 @@ export function DelegateCard({
           />
         </div>
 
-        <div className="flex items-center">
-          {Object.entries(socialMedia).map(([platform, url]) => (
-            <a
-              key={platform}
-              href={url ?? "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mr-4"
-            >
-              {getSocialIcon(platform)}
-            </a>
-          ))}
-        </div>
       </CardContent>
       <CardFooter>
         <Button

--- a/apps/account-portal/src/components/modules/homepage/homepage.tsx
+++ b/apps/account-portal/src/components/modules/homepage/homepage.tsx
@@ -49,18 +49,18 @@ import {
 
 import { ProposalList } from "../governance/proposal-list";
 
+/** Max realm cards shown on the homepage before "View All" */
+const HOMEPAGE_REALMS_PREVIEW_COUNT = 5;
+
+const INTERACTIVE_ROW_CLASS =
+  "realm-interactive-row group hover:bg-accent/70 rounded-lg p-4 transition-colors hover:border-[color:var(--realm-accent-brass)]";
+
+function StatValue({ children }: { children: React.ReactNode }) {
+  return <div className="realm-stat text-3xl font-bold">{children}</div>;
+}
+
 export function Homepage({ address }: { address: `0x${string}` }) {
-  //const { address } = useAccount();
   const { address: l1Address } = useL1Account();
-  /*const l2RealmsQuery = useSuspenseQuery(
-    getRealmsQueryOptions({
-      address,
-      collectionAddress: CollectionAddresses.realms[
-        SUPPORTED_L2_CHAIN_ID
-      ] as string,
-    }),
-  );
-  const l2Realms = l2RealmsQuery.data;*/
 
   const [l1UsersRealmsQuery, accountTokensQuery] = useSuspenseQueries({
     queries: [
@@ -140,9 +140,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="realm-stat text-3xl font-bold">
-                    {l1RealmCount}
-                  </div>
+                  <StatValue>{l1RealmCount}</StatValue>
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
                     <EthereumIcon className="h-4 w-4" />
                     Ethereum
@@ -151,9 +149,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               </div>
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="realm-stat text-3xl font-bold">
-                    {accountTokens?.length ?? 0}
-                  </div>
+                  <StatValue>{accountTokens?.length ?? 0}</StatValue>
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
                     <StarknetIcon className="h-4 w-4" />
                     Starknet
@@ -193,9 +189,9 @@ export function Homepage({ address }: { address: `0x${string}` }) {
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="realm-stat text-3xl font-bold">
+                  <StatValue>
                     {formatNumber(Number(l1Balance?.formatted ?? 0))}
-                  </div>
+                  </StatValue>
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
                     <EthereumIcon className="h-4 w-4" />
                     Ethereum
@@ -204,9 +200,9 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               </div>
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="realm-stat text-3xl font-bold">
+                  <StatValue>
                     {formatNumber(Number(starknetBalance?.formatted))}
-                  </div>
+                  </StatValue>
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
                     <StarknetIcon className="h-4 w-4" />
                     Starknet
@@ -215,11 +211,11 @@ export function Homepage({ address }: { address: `0x${string}` }) {
               </div>
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="realm-stat text-3xl font-bold">
+                  <StatValue>
                     {formatNumber(
                       Number(formatEther(BigInt(ownerLordsLock?.amount ?? 0))),
                     )}
-                  </div>
+                  </StatValue>
                   <div className="text-muted-foreground text-sm">
                     Staked (veLords)
                   </div>
@@ -239,7 +235,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
             <CardContent className="space-y-4">
               <div className="space-y-4">
                 <Link to={`/realms/claims`}>
-                  <div className="realm-interactive-row group hover:bg-accent/70 rounded-lg p-4 transition-colors hover:border-[color:var(--realm-accent-brass)]">
+                  <div className={INTERACTIVE_ROW_CLASS}>
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
                         <LordsIcon className="h-6 w-6" />
@@ -260,7 +256,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                 </Link>
 
                 <Link to={`/velords`}>
-                  <div className="realm-interactive-row group hover:bg-accent/70 rounded-lg p-4 transition-colors hover:border-[color:var(--realm-accent-brass)]">
+                  <div className={INTERACTIVE_ROW_CLASS}>
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
                         <LordsIcon className="h-6 w-6" />
@@ -384,7 +380,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-4">
                 <CardTitle>Your Realms</CardTitle>
-                {accountTokens.length > 5 && (
+                {accountTokens.length > HOMEPAGE_REALMS_PREVIEW_COUNT && (
                   <Link to={`/realms`}>
                     <Button variant="outline" size="sm">
                       View All ({accountTokens.length})
@@ -393,9 +389,9 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                 )}
               </CardHeader>
               <CardContent>
-                <div className="grid gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+                <div className="grid gap-4 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
                   {accountTokens
-                    .slice(0, 5)
+                    .slice(0, HOMEPAGE_REALMS_PREVIEW_COUNT)
                     .map((realm: RawTokenBalanceWithMetadata) => (
                       <RealmCard
                         key={realm.token_id}
@@ -403,7 +399,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                         isGrid={true}
                       />
                     ))}
-                  {accountTokens.length > 5 && (
+                  {accountTokens.length > HOMEPAGE_REALMS_PREVIEW_COUNT && (
                     <Card className="flex items-center justify-center">
                       <Link
                         to={`/realms`}
@@ -412,7 +408,7 @@ export function Homepage({ address }: { address: `0x${string}` }) {
                         <div className="text-center">
                           <Plus className="text-muted-foreground mx-auto h-8 w-8" />
                           <div className="text-muted-foreground mt-2 text-sm">
-                            +{accountTokens.length - 5} more
+                            +{accountTokens.length - HOMEPAGE_REALMS_PREVIEW_COUNT} more
                           </div>
                         </div>
                       </Link>

--- a/apps/account-portal/src/components/modules/realms/realm-card.tsx
+++ b/apps/account-portal/src/components/modules/realms/realm-card.tsx
@@ -15,6 +15,22 @@ export interface RealmMetadata {
   }[];
 }
 
+const GridDetails = ({
+  token,
+}: {
+  token: RealmMetadata | null;
+  address?: string;
+}) => (
+  <div className="flex h-full w-full flex-col justify-between">
+    <div className="pb-2">
+      <span className="truncate">{token?.name}</span>
+    </div>
+    <div className="h-[48px]">
+      <RealmResources traits={token?.attributes ?? []} />
+    </div>
+  </div>
+);
+
 export const RealmCard = ({
   token,
   isGrid,
@@ -36,17 +52,14 @@ export const RealmCard = ({
             src={image}
             alt={name ?? ""}
             mediaKey={""}
-            /*className={isGrid ? "mx-auto" : ""}
-  width={imageSize}
-  height={imageSize}*/
           />
         ) : (
-          <div className="w-96">
+          <div className="w-full max-w-sm">
             <AnimatedMap />
           </div>
         )}
         {isGrid && (
-          <span className="absolute bottom-1 right-1 bg-black px-1 py-1 text-xs">
+          <span className="absolute bottom-1 right-1 bg-foreground text-background px-1 py-1 text-xs">
             #{Number(token.token_id)}
           </span>
         )}
@@ -57,28 +70,3 @@ export const RealmCard = ({
     </Card>
   );
 };
-
-const GridDetails = ({
-  token,
-}: {
-  token: RealmMetadata | null;
-  address?: string;
-}) => (
-  <div className="flex h-full w-full flex-col justify-between">
-    <div className="flex justify-between pb-2">
-      <span className="truncate">{token?.name}</span>
-      <div className="flex justify-between font-sans">
-        {/*<Price token={token} />*/}
-        {/*token.last_price && (
-          <span className="flex text-bright-yellow/50">
-            {token.last_price}
-            <LordsIcon className="ml-2 h-4 w-4 self-center fill-current" />
-          </span>
-        )*/}
-      </div>
-    </div>
-    <div className="h-[48px]">
-      <RealmResources traits={token?.attributes ?? []} />
-    </div>
-  </div>
-);

--- a/apps/account-portal/src/components/modules/realms/realm-resources.tsx
+++ b/apps/account-portal/src/components/modules/realms/realm-resources.tsx
@@ -10,18 +10,24 @@ import {
 } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 
+/** Max visible resource icons on desktop */
+const VISIBLE_RESOURCES_DESKTOP = 4;
+/** Max visible resource icons on mobile */
+const VISIBLE_RESOURCES_MOBILE = 2;
+
 export default function RealmResources({
   traits,
 }: {
   traits: TokenMetadataAttribute[];
 }) {
   const resources = traits.filter((trait) => trait.trait_type === "Resource");
-  const hiddenCount = resources.length - 4;
   const isMobile = useIsMobile();
+  const visibleCount = isMobile ? VISIBLE_RESOURCES_MOBILE : VISIBLE_RESOURCES_DESKTOP;
+  const hiddenCount = resources.length - visibleCount;
 
   return (
     <div className="flex items-center gap-2">
-      {resources.slice(0, isMobile ? 2 : 4).map((resource, index) => (
+      {resources.slice(0, visibleCount).map((resource, index) => (
         <div
           key={index}
           className="bg-secondary flex items-center gap-2 rounded-lg p-2"
@@ -31,7 +37,7 @@ export default function RealmResources({
           )}
         </div>
       ))}
-      {resources.length > (isMobile ? 2 : 4) && (
+      {resources.length > visibleCount && (
         <>
           <TooltipProvider>
             <Tooltip>
@@ -47,7 +53,7 @@ export default function RealmResources({
                 side="top"
               >
                 <div className="flex items-center gap-2">
-                  {resources.slice(4).map((resource, index) => (
+                  {resources.slice(visibleCount).map((resource, index) => (
                     <div key={index} className="flex items-center gap-2">
                       <div>
                         <span className="text-xs">{resource.value}</span>

--- a/apps/account-portal/src/components/ui/button.tsx
+++ b/apps/account-portal/src/components/ui/button.tsx
@@ -10,15 +10,15 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground border-[color:var(--realm-border-etched)] shadow-[0_12px_24px_color-mix(in_oklab,var(--realm-accent-brass)_24%,transparent)] hover:-translate-y-0.5 hover:bg-[color:var(--realm-accent-ember)]",
+          "bg-primary text-primary-foreground border-realm-etched shadow-[0_12px_24px_color-mix(in_oklab,var(--realm-accent-brass)_24%,transparent)] hover:-translate-y-0.5 hover:bg-[color:var(--realm-accent-ember)]",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-xs",
         outline:
-          "bg-card/80 text-foreground hover:bg-accent/70 hover:text-primary border-[color:var(--realm-border-etched)] shadow-[inset_0_1px_0_color-mix(in_oklab,white_8%,transparent),0_10px_24px_color-mix(in_oklab,black_24%,transparent)] hover:border-[color:var(--realm-accent-brass)]",
+          "bg-card/80 text-foreground hover:bg-accent/70 hover:text-primary border-realm-etched shadow-[inset_0_1px_0_color-mix(in_oklab,white_8%,transparent),0_10px_24px_color-mix(in_oklab,black_24%,transparent)] hover:border-[color:var(--realm-accent-brass)]",
         secondary:
-          "bg-secondary/80 text-secondary-foreground hover:bg-secondary border-[color:var(--realm-border-etched)] shadow-xs",
+          "bg-secondary/80 text-secondary-foreground hover:bg-secondary border-realm-etched shadow-xs",
         ghost:
-          "text-foreground hover:bg-accent/60 hover:text-primary border-transparent bg-transparent hover:border-[color:var(--realm-border-etched)]",
+          "text-foreground hover:bg-accent/60 hover:text-primary border-transparent bg-transparent hover:border-realm-etched",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/apps/account-portal/src/components/ui/sidebar.tsx
+++ b/apps/account-portal/src/components/ui/sidebar.tsx
@@ -518,12 +518,12 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground active:bg-sidebar-accent/80 active:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent/80 data-[active=true]:text-primary data-[state=open]:hover:bg-sidebar-accent/80 data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-xl border border-transparent p-2 text-left text-sm font-semibold [letter-spacing:var(--tracking-ui)] uppercase outline-hidden transition-[width,height,padding,background-color,border-color,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:border-[color:var(--realm-border-etched)] data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground active:bg-sidebar-accent/80 active:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent/80 data-[active=true]:text-primary data-[state=open]:hover:bg-sidebar-accent/80 data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-xl border border-transparent p-2 text-left text-sm font-semibold [letter-spacing:var(--tracking-ui)] uppercase outline-hidden transition-[width,height,padding,background-color,border-color,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:border-realm-etched data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground hover:border-[color:var(--realm-border-etched)]",
+          "hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground hover:border-realm-etched",
         outline:
           "bg-background/70 hover:bg-sidebar-accent/80 hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--realm-border-etched)]",
       },
@@ -697,7 +697,7 @@ const SidebarMenuSub = React.forwardRef<
     ref={ref}
     data-sidebar="menu-sub"
     className={cn(
-      "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-[color:var(--realm-border-etched)] px-2.5 py-0.5",
+      "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-realm-etched px-2.5 py-0.5",
       "group-data-[collapsible=icon]:hidden",
       className,
     )}
@@ -729,8 +729,8 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground active:bg-sidebar-accent/70 active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-lg border border-transparent px-2 outline-hidden hover:border-[color:var(--realm-border-etched)] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
-        "data-[active=true]:bg-sidebar-accent/70 data-[active=true]:text-primary data-[active=true]:border-[color:var(--realm-border-etched)]",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground active:bg-sidebar-accent/70 active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-lg border border-transparent px-2 outline-hidden hover:border-realm-etched focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "data-[active=true]:bg-sidebar-accent/70 data-[active=true]:text-primary data-[active=true]:border-realm-etched",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",
         "group-data-[collapsible=icon]:hidden",

--- a/apps/account-portal/src/lib/theme.test.ts
+++ b/apps/account-portal/src/lib/theme.test.ts
@@ -65,7 +65,7 @@ describe("account portal theme", () => {
   });
 
   it("gives outline buttons an etched panel treatment", () => {
-    expect(buttonSource).toContain("border-[color:var(--realm-border-etched)]");
+    expect(buttonSource).toContain("border-realm-etched");
     expect(buttonSource).toContain("bg-card/80");
     expect(buttonSource).toContain(
       "hover:border-[color:var(--realm-accent-brass)]",

--- a/apps/account-portal/src/routes/realms.bridge.tsx
+++ b/apps/account-portal/src/routes/realms.bridge.tsx
@@ -153,7 +153,7 @@ function RouteComponent() {
           </div>
         </div>
         {selectedAsset === "Ethereum" && !l1Address && (
-          <Alert className="mb-4 rounded border-warning">
+          <Alert variant="warning" className="mb-4 rounded">
             <TriangleAlert className="h-5 w-5" />
             <AlertTitle className="text-lg">
               Your Ethereum wallet is not connected
@@ -164,7 +164,7 @@ function RouteComponent() {
           </Alert>
         )}
         {selectedAsset === "Starknet" && !l2Address && (
-          <Alert className="mb-4 rounded border-warning">
+          <Alert variant="warning" className="mb-4 rounded">
             <TriangleAlert className="h-5 w-5" />
             <AlertTitle className="text-lg">
               Your Starknet wallet is not connected

--- a/apps/account-portal/src/routes/realms.index.tsx
+++ b/apps/account-portal/src/routes/realms.index.tsx
@@ -81,7 +81,7 @@ function RealmsComponent() {
           </Button>
         </Link>
       </div>
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-5 sm:p-4">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-5">
         {l2Realms?.length
           ? l2Realms.map((realm) => {
               return (

--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -388,6 +388,12 @@
   }
 }
 
+@layer utilities {
+  .border-realm-etched {
+    border-color: var(--realm-border-etched);
+  }
+}
+
 ::-webkit-scrollbar,
 .table-scroll::-webkit-scrollbar {
   width: 0.3em;


### PR DESCRIPTION
## Summary
- Replace hardcoded colors (`bg-black`, `border-warning`) with theme tokens (`bg-foreground`, `variant="warning"`)
- Remove dead code: commented-out blocks in realm-card, unused `getSocialIcon` + empty social links in delegate-card
- Extract `StatValue` component and `INTERACTIVE_ROW_CLASS` constant to deduplicate homepage patterns
- Extract `.border-realm-etched` CSS utility, replacing 10 raw `border-[color:var(--realm-border-etched)]` references across button.tsx and sidebar.tsx
- Standardize responsive grid breakpoints to `md`/`lg`/`xl` progression
- Replace magic numbers with named constants (`HOMEPAGE_REALMS_PREVIEW_COUNT`, `VISIBLE_RESOURCES_DESKTOP`, `VISIBLE_RESOURCES_MOBILE`)
- Use existing `realm-card-title` CSS class instead of manual font composition in login-card
- Reorder nested component definitions (`FeatureItem`, `GridDetails`) above parent components

## Test plan
- [ ] Verify homepage renders correctly with StatValue component and grid breakpoints
- [ ] Verify bridge page alerts display with warning variant styling
- [ ] Verify realm cards display with theme token colors instead of hardcoded black
- [ ] Verify sidebar and button border styling unchanged visually
- [ ] Verify realm resources tooltip still shows correct count on mobile and desktop
- [ ] Verify login card feature items render with correct typography

🤖 Generated with [Claude Code](https://claude.com/claude-code)