### PR TITLE
Fix wallet connect modal rendering off-screen on Bridge page

### DIFF
--- a/apps/account-portal/src/styles.css
+++ b/apps/account-portal/src/styles.css
@@ -254,7 +254,12 @@
     content: none;
   }
 
-  body > * {
+  /* Scope the app's stacking context to real content children only.
+     Overlay web components that AppKit/Reown append directly to <body>
+     (e.g. <w3m-modal>) set their own `position: fixed` on the host element,
+     which a blanket `body > *` rule would clobber — parking the wallet modal
+     off-screen. Exclude them so their fixed positioning survives. */
+  body > *:not(w3m-modal):not(wcm-modal):not(appkit-modal) {
     position: relative;
     z-index: 1;
   }


### PR DESCRIPTION
## Problem

On the Bridge page (and anywhere the Ethereum "Connect Wallet" button appears), clicking **Connect** shows an endless spinner and no wallet dialog. Reproducible for all users, not client-specific. Connecting via the header (Starknet) works fine.

## Root cause

Purely a CSS layout bug — not the wallet, network, or AppKit itself.

`src/styles.css` had:

```css
body > * {
  position: relative;
  z-index: 1;
}
```

Reown AppKit appends its `<w3m-modal>` as a **direct child of `<body>`**, so `body > *` matched it and overrode the modal's own `position: fixed` with `relative`. The modal opened and fully rendered, but laid out in normal document flow — right after the full-height (`h-screen`) app shell — landing **below the viewport**. So the dialog was open but parked off-screen.

This explains every symptom:
- Button spins, "no dialog" → the dialog exists in the DOM, just off-screen.
- No console error, AppKit API calls return 200 → nothing failed; only the final position was wrong.
- Everyone affected → it's CSS, independent of wallet/network/browser.
- Header works → Starknet flow doesn't use the AppKit modal.

The rule came from the recent portal-styles cleanup and is effectively vestigial (the `body::before` background it was stacking above is now `content: none`).

## Fix

Exclude AppKit/Reown overlay web components (which set `position: fixed` on the host element itself) from the blanket rule:

```css
body > *:not(w3m-modal):not(wcm-modal):not(appkit-modal) {
  position: relative;
  z-index: 1;
}
```

Radix dialogs/toasts are unaffected — their fixed content lives inside a portal wrapper, not on the `body > *` host directly.

## Verification

Confirmed in-browser against the local build: after the change the modal computes `position: fixed`, `z-index: 9999`, `inset: 0`, and the wallet list renders centered and visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)